### PR TITLE
Add `default` case for `switch` block to eliminate Xcode warnings

### DIFF
--- a/ChattoAdditions/Source/UI Components/CircleProgressIndicatorView/BMACircleIconView.m
+++ b/ChattoAdditions/Source/UI Components/CircleProgressIndicatorView/BMACircleIconView.m
@@ -129,6 +129,8 @@ struct BMACircleProgressIconPoints {
             points.bma_left = CGPointMake(points.bma_centre.x - (self.outterCircleRadius - self.horizontalMargin), points.bma_centre.y);
             points.bma_right = CGPointMake(points.bma_centre.x + (self.outterCircleRadius - self.horizontalMargin), points.bma_centre.y);
             break;
+        default:
+            break;
     }
 
     self.iconPoints = points;

--- a/ChattoAdditions/Source/UI Components/CircleProgressIndicatorView/BMACircleProgressIndicatorView.m
+++ b/ChattoAdditions/Source/UI Components/CircleProgressIndicatorView/BMACircleProgressIndicatorView.m
@@ -137,6 +137,8 @@
             break;
         case BMACircleProgressStatusCompleted:
             break;
+        default:
+            break;
     }
 }
 
@@ -166,6 +168,8 @@
             break;
         case BMACircleProgressStatusCompleted:
             [self.circleIconView setType:BMACircleIconTypeCheck];
+            break;
+        default:
             break;
     }
 }


### PR DESCRIPTION
Hi badoo team, please let me know if the changes are OK. Or if you have other plan to deal with the un-handled enum values in `switch` block.

Thanks. 