### PR TITLE
Relaxes generic constraints in Presenters

### DIFF
--- a/ChattoAdditions/Source/Chat Items/BaseMessage/BaseMessagePresenter.swift
+++ b/ChattoAdditions/Source/Chat Items/BaseMessage/BaseMessagePresenter.swift
@@ -28,6 +28,7 @@ import Chatto
 public protocol ViewModelBuilderProtocol {
     typealias ModelT: MessageModelProtocol
     typealias ViewModelT: MessageViewModelProtocol
+    func canCreateViewModel(fromModel model: Any) -> Bool
     func createViewModel(model: ModelT) -> ViewModelT
 }
 
@@ -40,7 +41,6 @@ public protocol BaseMessageInteractionHandlerProtocol {
 
 public class BaseMessagePresenter<BubbleViewT, ViewModelBuilderT, InteractionHandlerT where
     ViewModelBuilderT: ViewModelBuilderProtocol,
-    ViewModelBuilderT.ModelT: MessageModelProtocol,
     ViewModelBuilderT.ViewModelT: MessageViewModelProtocol,
     InteractionHandlerT: BaseMessageInteractionHandlerProtocol,
     InteractionHandlerT.ViewModelT == ViewModelBuilderT.ViewModelT,

--- a/ChattoAdditions/Source/Chat Items/PhotoMessages/PhotoMessagePresenter.swift
+++ b/ChattoAdditions/Source/Chat Items/PhotoMessages/PhotoMessagePresenter.swift
@@ -26,7 +26,6 @@ import Foundation
 
 public class PhotoMessagePresenter<ViewModelBuilderT, InteractionHandlerT where
     ViewModelBuilderT: ViewModelBuilderProtocol,
-    ViewModelBuilderT.ModelT: PhotoMessageModelProtocol,
     ViewModelBuilderT.ViewModelT: PhotoMessageViewModelProtocol,
     InteractionHandlerT: BaseMessageInteractionHandlerProtocol,
     InteractionHandlerT.ViewModelT == ViewModelBuilderT.ViewModelT>

--- a/ChattoAdditions/Source/Chat Items/PhotoMessages/PhotoMessagePresenterBuilder.swift
+++ b/ChattoAdditions/Source/Chat Items/PhotoMessages/PhotoMessagePresenterBuilder.swift
@@ -27,7 +27,6 @@ import Chatto
 
 public class PhotoMessagePresenterBuilder<ViewModelBuilderT, InteractionHandlerT where
     ViewModelBuilderT: ViewModelBuilderProtocol,
-    ViewModelBuilderT.ModelT: PhotoMessageModelProtocol,
     ViewModelBuilderT.ViewModelT: PhotoMessageViewModelProtocol,
     InteractionHandlerT: BaseMessageInteractionHandlerProtocol,
     InteractionHandlerT.ViewModelT == ViewModelBuilderT.ViewModelT
@@ -49,7 +48,7 @@ public class PhotoMessagePresenterBuilder<ViewModelBuilderT, InteractionHandlerT
     public lazy var baseCellStyle: BaseMessageCollectionViewCellStyleProtocol = BaseMessageCollectionViewCellDefaultSyle()
 
     public func canHandleChatItem(chatItem: ChatItemProtocol) -> Bool {
-        return chatItem is PhotoMessageModelProtocol ? true : false
+        return self.viewModelBuilder.canCreateViewModel(fromModel: chatItem)
     }
 
     public func createPresenterWithChatItem(chatItem: ChatItemProtocol) -> ChatItemPresenterProtocol {

--- a/ChattoAdditions/Source/Chat Items/PhotoMessages/PhotoMessageViewModel.swift
+++ b/ChattoAdditions/Source/Chat Items/PhotoMessages/PhotoMessageViewModel.swift
@@ -80,18 +80,18 @@ public class PhotoMessageViewModel: PhotoMessageViewModelProtocol {
     }
 }
 
-public class PhotoMessageViewModelDefaultBuilder: ViewModelBuilderProtocol {
+public class PhotoMessageViewModelDefaultBuilder<ModelT: PhotoMessageModelProtocol>: ViewModelBuilderProtocol {
     public init() { }
 
     let messageViewModelBuilder = MessageViewModelDefaultBuilder()
 
-    public func createViewModel(model: PhotoMessageModel) -> PhotoMessageViewModel {
+    public func createViewModel(model: ModelT) -> PhotoMessageViewModel {
         let messageViewModel = self.messageViewModelBuilder.createMessageViewModel(model)
         let photoMessageViewModel = PhotoMessageViewModel(photoMessage: model, messageViewModel: messageViewModel)
         return photoMessageViewModel
     }
 
     public func canCreateViewModel(fromModel model: Any) -> Bool {
-        return model is PhotoMessageModel
+        return model is ModelT
     }
 }

--- a/ChattoAdditions/Source/Chat Items/PhotoMessages/PhotoMessageViewModel.swift
+++ b/ChattoAdditions/Source/Chat Items/PhotoMessages/PhotoMessageViewModel.swift
@@ -90,4 +90,8 @@ public class PhotoMessageViewModelDefaultBuilder: ViewModelBuilderProtocol {
         let photoMessageViewModel = PhotoMessageViewModel(photoMessage: model, messageViewModel: messageViewModel)
         return photoMessageViewModel
     }
+
+    public func canCreateViewModel(fromModel model: Any) -> Bool {
+        return model is PhotoMessageModel
+    }
 }

--- a/ChattoAdditions/Source/Chat Items/TextMessages/TextMessagePresenter.swift
+++ b/ChattoAdditions/Source/Chat Items/TextMessages/TextMessagePresenter.swift
@@ -26,7 +26,6 @@ import UIKit
 
 public class TextMessagePresenter<ViewModelBuilderT, InteractionHandlerT where
     ViewModelBuilderT: ViewModelBuilderProtocol,
-    ViewModelBuilderT.ModelT: TextMessageModelProtocol,
     ViewModelBuilderT.ViewModelT: TextMessageViewModelProtocol,
     InteractionHandlerT: BaseMessageInteractionHandlerProtocol,
     InteractionHandlerT.ViewModelT == ViewModelBuilderT.ViewModelT>

--- a/ChattoAdditions/Source/Chat Items/TextMessages/TextMessagePresenterBuilder.swift
+++ b/ChattoAdditions/Source/Chat Items/TextMessages/TextMessagePresenterBuilder.swift
@@ -27,7 +27,6 @@ import Chatto
 
 public class TextMessagePresenterBuilder<ViewModelBuilderT, InteractionHandlerT where
     ViewModelBuilderT: ViewModelBuilderProtocol,
-    ViewModelBuilderT.ModelT: TextMessageModelProtocol,
     ViewModelBuilderT.ViewModelT: TextMessageViewModelProtocol,
     InteractionHandlerT: BaseMessageInteractionHandlerProtocol,
     InteractionHandlerT.ViewModelT == ViewModelBuilderT.ViewModelT>
@@ -63,7 +62,7 @@ public class TextMessagePresenterBuilder<ViewModelBuilderT, InteractionHandlerT 
     public lazy var baseMessageStyle: BaseMessageCollectionViewCellStyleProtocol = BaseMessageCollectionViewCellDefaultSyle()
 
     public func canHandleChatItem(chatItem: ChatItemProtocol) -> Bool {
-        return chatItem is TextMessageModelProtocol ? true : false
+        return self.viewModelBuilder.canCreateViewModel(fromModel: chatItem)
     }
 
     public func createPresenterWithChatItem(chatItem: ChatItemProtocol) -> ChatItemPresenterProtocol {

--- a/ChattoAdditions/Source/Chat Items/TextMessages/TextMessageViewModel.swift
+++ b/ChattoAdditions/Source/Chat Items/TextMessages/TextMessageViewModel.swift
@@ -38,12 +38,12 @@ public class TextMessageViewModel: TextMessageViewModelProtocol {
     }
 }
 
-public class TextMessageViewModelDefaultBuilder: ViewModelBuilderProtocol {
+public class TextMessageViewModelDefaultBuilder<ModelT: TextMessageModelProtocol>: ViewModelBuilderProtocol {
     public init() { }
 
     let messageViewModelBuilder = MessageViewModelDefaultBuilder()
 
-    public func createViewModel(model: TextMessageModel) -> TextMessageViewModel {
+    public func createViewModel(model: ModelT) -> TextMessageViewModel {
         let messageViewModel = self.messageViewModelBuilder.createMessageViewModel(model)
         let textMessageViewModel = TextMessageViewModel(text: model.text, messageViewModel: messageViewModel)
         return textMessageViewModel
@@ -51,6 +51,6 @@ public class TextMessageViewModelDefaultBuilder: ViewModelBuilderProtocol {
     }
 
     public func canCreateViewModel(fromModel model: Any) -> Bool {
-        return model is TextMessageModel
+        return model is ModelT
     }
 }

--- a/ChattoAdditions/Source/Chat Items/TextMessages/TextMessageViewModel.swift
+++ b/ChattoAdditions/Source/Chat Items/TextMessages/TextMessageViewModel.swift
@@ -49,4 +49,8 @@ public class TextMessageViewModelDefaultBuilder: ViewModelBuilderProtocol {
         return textMessageViewModel
 
     }
+
+    public func canCreateViewModel(fromModel model: Any) -> Bool {
+        return model is TextMessageModel
+    }
 }

--- a/ChattoAdditions/Tests/Chat Items/BaseMessage/BaseMessagePresenterTests.swift
+++ b/ChattoAdditions/Tests/Chat Items/BaseMessage/BaseMessagePresenterTests.swift
@@ -29,11 +29,11 @@ import Chatto
 class BaseMessagePresenterTests: XCTestCase {
 
     // BaseMessagePresenter is generic, let's use the photo one for instance
-    var presenter: PhotoMessagePresenter<PhotoMessageViewModelDefaultBuilder, PhotoMessageTestHandler>!
+    var presenter: PhotoMessagePresenter<PhotoMessageViewModelDefaultBuilder<PhotoMessageModel>, PhotoMessageTestHandler>!
     let decorationAttributes = ChatItemDecorationAttributes(bottomMargin: 0, showsTail: false)
     var interactionHandler: PhotoMessageTestHandler!
     override func setUp() {
-        let viewModelBuilder = PhotoMessageViewModelDefaultBuilder()
+        let viewModelBuilder = PhotoMessageViewModelDefaultBuilder<PhotoMessageModel>()
         let sizingCell = PhotoMessageCollectionViewCell.sizingCell()
         let photoStyle = PhotoMessageCollectionViewCellDefaultStyle()
         let baseStyle = BaseMessageCollectionViewCellDefaultSyle()

--- a/ChattoAdditions/Tests/Chat Items/PhotoMessages/PhotoMessagePresenterBuilderTests.swift
+++ b/ChattoAdditions/Tests/Chat Items/PhotoMessages/PhotoMessagePresenterBuilderTests.swift
@@ -30,7 +30,7 @@ class PhotoMessagePresenterBuilderTests: XCTestCase {
     func testThat_CreatesPresenter() {
         let messageModel = MessageModel(uid: "uid", senderId: "senderId", type: "photo-message", isIncoming: true, date: NSDate(), status: .Success)
         let photoMessageModel = PhotoMessageModel(messageModel: messageModel, imageSize: CGSize(width: 30, height: 30), image: UIImage())
-        let builder = PhotoMessagePresenterBuilder(viewModelBuilder: PhotoMessageViewModelDefaultBuilder(), interactionHandler: PhotoMessageTestHandler())
+        let builder = PhotoMessagePresenterBuilder(viewModelBuilder: PhotoMessageViewModelDefaultBuilder<PhotoMessageModel>(), interactionHandler: PhotoMessageTestHandler())
         XCTAssertNotNil(builder.createPresenterWithChatItem(photoMessageModel))
     }
 }

--- a/ChattoAdditions/Tests/Chat Items/PhotoMessages/PhotoMessagePresenterTests.swift
+++ b/ChattoAdditions/Tests/Chat Items/PhotoMessages/PhotoMessagePresenterTests.swift
@@ -27,11 +27,11 @@ import XCTest
 
 class PhotoMessagePresenterTests: XCTestCase, UICollectionViewDataSource {
 
-    var presenter: PhotoMessagePresenter<PhotoMessageViewModelDefaultBuilder, PhotoMessageTestHandler>!
+    var presenter: PhotoMessagePresenter<PhotoMessageViewModelDefaultBuilder<PhotoMessageModel>, PhotoMessageTestHandler>!
     let decorationAttributes = ChatItemDecorationAttributes(bottomMargin: 0, showsTail: false)
     let testImage = UIImage()
     override func setUp() {
-        let viewModelBuilder = PhotoMessageViewModelDefaultBuilder()
+        let viewModelBuilder = PhotoMessageViewModelDefaultBuilder<PhotoMessageModel>()
         let sizingCell = PhotoMessageCollectionViewCell.sizingCell()
         let photoStyle = PhotoMessageCollectionViewCellDefaultStyle()
         let baseStyle = BaseMessageCollectionViewCellDefaultSyle()
@@ -57,7 +57,7 @@ class PhotoMessagePresenterTests: XCTestCase, UICollectionViewDataSource {
 
     func testThat_RegistersAndDequeuesCells() {
         let collectionView = UICollectionView(frame: CGRect.zero, collectionViewLayout: UICollectionViewFlowLayout())
-        PhotoMessagePresenter<PhotoMessageViewModelDefaultBuilder, PhotoMessageTestHandler>.registerCells(collectionView)
+        PhotoMessagePresenter<PhotoMessageViewModelDefaultBuilder<PhotoMessageModel>, PhotoMessageTestHandler>.registerCells(collectionView)
         collectionView.dataSource = self
         collectionView.reloadData()
         XCTAssertNotNil(self.presenter.dequeueCell(collectionView: collectionView, indexPath: NSIndexPath(forItem: 0, inSection: 0)))

--- a/ChattoAdditions/Tests/Chat Items/TextMessages/TextMessagePresenterBuilderTests.swift
+++ b/ChattoAdditions/Tests/Chat Items/TextMessages/TextMessagePresenterBuilderTests.swift
@@ -30,7 +30,7 @@ class TextMessagePresenterBuilderTests: XCTestCase {
     func testThat_CreatesPresenter() {
         let messageModel = MessageModel(uid: "uid", senderId: "senderId", type: "text-message", isIncoming: true, date: NSDate(), status: .Success)
         let textMessageModel = TextMessageModel(messageModel: messageModel, text: "Some text")
-        let builder = TextMessagePresenterBuilder(viewModelBuilder: TextMessageViewModelDefaultBuilder(), interactionHandler: TextMessageTestHandler())
+        let builder = TextMessagePresenterBuilder(viewModelBuilder: TextMessageViewModelDefaultBuilder<TextMessageModel>(), interactionHandler: TextMessageTestHandler())
         XCTAssertNotNil(builder.createPresenterWithChatItem(textMessageModel))
     }
 }

--- a/ChattoAdditions/Tests/Chat Items/TextMessages/TextMessagePresenterTests.swift
+++ b/ChattoAdditions/Tests/Chat Items/TextMessages/TextMessagePresenterTests.swift
@@ -28,10 +28,10 @@ import Chatto
 
 class TextMessagePresenterTests: XCTestCase, UICollectionViewDataSource {
 
-    var presenter: TextMessagePresenter<TextMessageViewModelDefaultBuilder, TextMessageTestHandler>!
+    var presenter: TextMessagePresenter<TextMessageViewModelDefaultBuilder<TextMessageModel>, TextMessageTestHandler>!
     let decorationAttributes = ChatItemDecorationAttributes(bottomMargin: 0, showsTail: false)
     override func setUp() {
-        let viewModelBuilder = TextMessageViewModelDefaultBuilder()
+        let viewModelBuilder = TextMessageViewModelDefaultBuilder<TextMessageModel>()
         let sizingCell = TextMessageCollectionViewCell.sizingCell()
         let textStyle = TextMessageCollectionViewCellDefaultStyle()
         let baseStyle = BaseMessageCollectionViewCellDefaultSyle()
@@ -43,7 +43,7 @@ class TextMessagePresenterTests: XCTestCase, UICollectionViewDataSource {
     func testThat_RegistersAndDequeuesCells() {
 
         let collectionView = UICollectionView(frame: CGRect.zero, collectionViewLayout: UICollectionViewFlowLayout())
-        TextMessagePresenter<TextMessageViewModelDefaultBuilder, TextMessageTestHandler>.registerCells(collectionView)
+        TextMessagePresenter<TextMessageViewModelDefaultBuilder<TextMessageModel>, TextMessageTestHandler>.registerCells(collectionView)
         collectionView.dataSource = self
         collectionView.reloadData()
         XCTAssertNotNil(self.presenter.dequeueCell(collectionView: collectionView, indexPath: NSIndexPath(forItem: 0, inSection: 0)))

--- a/ChattoApp/ChattoApp/DemoChatViewController.swift
+++ b/ChattoApp/ChattoApp/DemoChatViewController.swift
@@ -71,7 +71,7 @@ class DemoChatViewController: BaseChatViewController {
         return [
             TextMessageModel.chatItemType: [
                 TextMessagePresenterBuilder(
-                    viewModelBuilder: TextMessageViewModelDefaultBuilder(),
+                    viewModelBuilder: TextMessageViewModelDefaultBuilder<TextMessageModel>(),
                     interactionHandler: TextMessageHandler(baseHandler: self.baseMessageHandler)
                 )
             ],

--- a/ChattoApp/ChattoApp/FakePhotoMessageViewModel.swift
+++ b/ChattoApp/ChattoApp/FakePhotoMessageViewModel.swift
@@ -74,4 +74,8 @@ public class FakePhotoMessageViewModelBuilder: ViewModelBuilderProtocol {
         let photoMessageViewModel = FakePhotoMessageViewModel(photoMessage: model, messageViewModel: messageViewModel)
         return photoMessageViewModel
     }
+
+    public func canCreateViewModel(fromModel model: Any) -> Bool {
+        return model is PhotoMessageModel
+    }
 }

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ override func createPresenterBuilders() -> [ChatItemType: [ChatItemPresenterBuil
     return [
         TextMessageModel.chatItemType: [
             TextMessagePresenterBuilder(
-                viewModelBuilder: TextMessageViewModelDefaultBuilder(),
+                viewModelBuilder: TextMessageViewModelDefaultBuilder<TextMessageModel>(),
                 interactionHandler: TextMessageHandler(baseHandler: self.baseMessageHandler)
             )
         ]


### PR DESCRIPTION
Presenters shouldn't have any restriction about what models they receive. Their responsability is to present a CollectionViewCell and they only need a ViewModel for that. Therefore, it's responsability of the ViewModelBuilder to be able to provide a ViewModel for a especific model and it's there where the type constraint should reside. 

For instance, this allows reusing a PhotoMessagePresenter without having a model conforming to PhotoMessageModelProtocol.