### PR TITLE
Removes completion block from pagination calls.

### DIFF
--- a/Chatto/Source/ChatController/BaseChatViewController+Scrolling.swift
+++ b/Chatto/Source/ChatController/BaseChatViewController+Scrolling.swift
@@ -117,13 +117,9 @@ extension BaseChatViewController {
         guard self.autoLoadingEnabled, let dataSource = self.chatDataSource else { return }
 
         if self.isCloseToTop() && dataSource.hasMorePrevious {
-            dataSource.loadPrevious({ [weak self] () -> Void in
-                self?.enqueueModelUpdate(context: .Pagination)
-            })
+            dataSource.loadPrevious()
         } else if self.isCloseToBottom() && dataSource.hasMoreNext {
-            dataSource.loadNext({ [weak self] () -> Void in
-                self?.enqueueModelUpdate(context: .Pagination)
-            })
+            dataSource.loadNext()
         }
     }
 }

--- a/Chatto/Source/ChatController/BaseChatViewController.swift
+++ b/Chatto/Source/ChatController/BaseChatViewController.swift
@@ -44,7 +44,7 @@ public class BaseChatViewController: UIViewController, UICollectionViewDataSourc
     public var chatDataSource: ChatDataSourceProtocol? {
         didSet {
             self.chatDataSource?.delegate = self
-            self.enqueueModelUpdate(context: .Reload)
+            self.enqueueModelUpdate(updateType: .Reload)
         }
     }
 

--- a/Chatto/Source/ChatController/ChatDataSourceProtocol.swift
+++ b/Chatto/Source/ChatController/ChatDataSourceProtocol.swift
@@ -24,7 +24,7 @@
 
 import Foundation
 
-public enum UpdateContext {
+public enum UpdateType {
     case Normal
     case FirstLoad
     case Pagination
@@ -34,7 +34,7 @@ public enum UpdateContext {
 
 public protocol ChatDataSourceDelegateProtocol: class {
     func chatDataSourceDidUpdate(chatDataSource: ChatDataSourceProtocol)
-    func chatDataSourceDidUpdate(chatDataSource: ChatDataSourceProtocol, context: UpdateContext)
+    func chatDataSourceDidUpdate(chatDataSource: ChatDataSourceProtocol, updateType: UpdateType)
 }
 
 public protocol ChatDataSourceProtocol: class {
@@ -43,7 +43,7 @@ public protocol ChatDataSourceProtocol: class {
     var chatItems: [ChatItemProtocol] { get }
     weak var delegate: ChatDataSourceDelegateProtocol? { get set }
 
-    func loadNext(completion: () -> Void)
-    func loadPrevious(completion: () -> Void)
+    func loadNext() // Should trigger chatDataSourceDidUpdate with UpdateType.Pagination
+    func loadPrevious() // Should trigger chatDataSourceDidUpdate with UpdateType.Pagination
     func adjustNumberOfMessages(preferredMaxCount preferredMaxCount: Int?, focusPosition: Double, completion:(didAdjust: Bool) -> Void) // If you want, implement message count contention for performance, otherwise just call completion(false)
 }

--- a/Chatto/Tests/ChatController/BaseChatViewControllerTestHelpers.swift
+++ b/Chatto/Tests/ChatController/BaseChatViewControllerTestHelpers.swift
@@ -62,16 +62,16 @@ class FakeDataSource: ChatDataSourceProtocol {
     var chatItems = [ChatItemProtocol]()
     weak var delegate: ChatDataSourceDelegateProtocol?
 
-    func loadNext(completion: () -> Void) {
+    func loadNext() {
         if let chatItemsForLoadNext = self.chatItemsForLoadNext {
             self.chatItems = chatItemsForLoadNext
         }
-        completion()
+        self.delegate?.chatDataSourceDidUpdate(self, updateType: .Pagination)
     }
 
-    func loadPrevious(completion: () -> Void) {
+    func loadPrevious() {
         self.wasRequestedForPrevious = true
-        completion()
+        self.delegate?.chatDataSourceDidUpdate(self, updateType: .Pagination)
     }
 
     func adjustNumberOfMessages(preferredMaxCount preferredMaxCount: Int?, focusPosition: Double, completion:(didAdjust: Bool) -> Void) {

--- a/ChattoApp/ChattoApp/Source/FakeDataSource.swift
+++ b/ChattoApp/ChattoApp/Source/FakeDataSource.swift
@@ -64,16 +64,16 @@ class FakeDataSource: ChatDataSourceProtocol {
 
     weak var delegate: ChatDataSourceDelegateProtocol?
 
-    func loadNext(completion: () -> Void) {
+    func loadNext() {
         self.slidingWindow.loadNext()
         self.slidingWindow.adjustWindow(focusPosition: 1, maxWindowSize: self.preferredMaxWindowSize)
-        completion()
+        self.delegate?.chatDataSourceDidUpdate(self, updateType: .Pagination)
     }
 
-    func loadPrevious(completion: () -> Void) {
+    func loadPrevious() {
         self.slidingWindow.loadPrevious()
         self.slidingWindow.adjustWindow(focusPosition: 0, maxWindowSize: self.preferredMaxWindowSize)
-        completion()
+        self.delegate?.chatDataSourceDidUpdate(self, updateType: .Pagination)
     }
 
     func addTextMessage(text: String) {


### PR DESCRIPTION
Now DataSource is responsible for notifying the exact type of change. This implicitly allows more flexibility in the dataSource ( like ignoring such a request! ) and reduces entry points from where changes are enqueued