### PR TITLE
Make Subclassing BaseMessageCollectionViewCell Possible Outside of Ch…

### DIFF
--- a/ChattoAdditions/Source/Chat Items/BaseMessage/Views/BaseMessageCollectionViewCell.swift
+++ b/ChattoAdditions/Source/Chat Items/BaseMessage/Views/BaseMessageCollectionViewCell.swift
@@ -77,7 +77,7 @@ public class BaseMessageCollectionViewCell<BubbleViewType where BubbleViewType:U
         }
     }
 
-    var messageViewModel: MessageViewModelProtocol! {
+    public var messageViewModel: MessageViewModelProtocol! {
         didSet {
             updateViews()
         }
@@ -112,12 +112,12 @@ public class BaseMessageCollectionViewCell<BubbleViewType where BubbleViewType:U
     }
 
     public private(set) var bubbleView: BubbleViewType!
-    func createBubbleView() -> BubbleViewType! {
+    public func createBubbleView() -> BubbleViewType! {
         assert(false, "Override in subclass")
         return nil
     }
 
-    override init(frame: CGRect) {
+    public override init(frame: CGRect) {
         super.init(frame: frame)
         self.commonInit()
     }

--- a/ChattoAdditions/Source/Chat Items/PhotoMessages/Views/PhotoMessageCollectionViewCell.swift
+++ b/ChattoAdditions/Source/Chat Items/PhotoMessages/Views/PhotoMessageCollectionViewCell.swift
@@ -38,7 +38,7 @@ public final class PhotoMessageCollectionViewCell: BaseMessageCollectionViewCell
         super.init(frame: frame)
     }
 
-    override func createBubbleView() -> PhotoBubbleView {
+    public override func createBubbleView() -> PhotoBubbleView {
         return PhotoBubbleView()
     }
 

--- a/ChattoAdditions/Source/Chat Items/TextMessages/Views/TextMessageCollectionViewCell.swift
+++ b/ChattoAdditions/Source/Chat Items/TextMessages/Views/TextMessageCollectionViewCell.swift
@@ -40,7 +40,7 @@ public final class TextMessageCollectionViewCell: BaseMessageCollectionViewCell<
 
     // MARK: Subclassing (view creation)
 
-    override func createBubbleView() -> TextBubbleView {
+    public override func createBubbleView() -> TextBubbleView {
         return TextBubbleView()
     }
 


### PR DESCRIPTION
…attoAdditions Module

-This commit exposes `messageViewModel`, `createBubbleView()` and `init`
functions of `BaseMessageCollectionViewCell` class to other modules by
changing their access modifiers to `public`.
-This also requires to change the access level of `createBubbleView()`
function of  `TextMessageCollectionViewCell` and
`PhotoMessageCollectionViewCell` to be made `public`