### PR TITLE
Input bar delegation

### DIFF
--- a/ChattoAdditions/ChattoAdditions.xcodeproj/project.pbxproj
+++ b/ChattoAdditions/ChattoAdditions.xcodeproj/project.pbxproj
@@ -70,7 +70,7 @@
 		C3C0CC851BFE49700052747C /* ChatInputBarTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3C0CC771BFE49700052747C /* ChatInputBarTests.swift */; };
 		C3C0CC861BFE49700052747C /* ChatInputItemTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3C0CC781BFE49700052747C /* ChatInputItemTests.swift */; };
 		C3C0CC871BFE49700052747C /* ChatInputItemViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3C0CC791BFE49700052747C /* ChatInputItemViewTests.swift */; };
-		C3C0CC881BFE49700052747C /* ChatInputManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3C0CC7A1BFE49700052747C /* ChatInputManagerTests.swift */; };
+		C3C0CC881BFE49700052747C /* ChatInputPresenterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3C0CC7A1BFE49700052747C /* ChatInputPresenterTests.swift */; };
 		C3C0CC891BFE49700052747C /* LiveCameraCellTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3C0CC7B1BFE49700052747C /* LiveCameraCellTests.swift */; };
 		C3C0CC8A1BFE49700052747C /* PhotosChatInputItemTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3C0CC7C1BFE49700052747C /* PhotosChatInputItemTests.swift */; };
 		C3C0CC8B1BFE49700052747C /* PhotosInputViewItemSizeCalculatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3C0CC7D1BFE49700052747C /* PhotosInputViewItemSizeCalculatorTests.swift */; };
@@ -156,7 +156,7 @@
 		C3C0CC771BFE49700052747C /* ChatInputBarTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ChatInputBarTests.swift; sourceTree = "<group>"; };
 		C3C0CC781BFE49700052747C /* ChatInputItemTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ChatInputItemTests.swift; sourceTree = "<group>"; };
 		C3C0CC791BFE49700052747C /* ChatInputItemViewTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ChatInputItemViewTests.swift; sourceTree = "<group>"; };
-		C3C0CC7A1BFE49700052747C /* ChatInputManagerTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ChatInputManagerTests.swift; sourceTree = "<group>"; };
+		C3C0CC7A1BFE49700052747C /* ChatInputPresenterTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ChatInputPresenterTests.swift; sourceTree = "<group>"; };
 		C3C0CC7B1BFE49700052747C /* LiveCameraCellTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LiveCameraCellTests.swift; sourceTree = "<group>"; };
 		C3C0CC7C1BFE49700052747C /* PhotosChatInputItemTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PhotosChatInputItemTests.swift; sourceTree = "<group>"; };
 		C3C0CC7D1BFE49700052747C /* PhotosInputViewItemSizeCalculatorTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PhotosInputViewItemSizeCalculatorTests.swift; sourceTree = "<group>"; };
@@ -410,7 +410,7 @@
 				C3C0CC771BFE49700052747C /* ChatInputBarTests.swift */,
 				C3C0CC781BFE49700052747C /* ChatInputItemTests.swift */,
 				C3C0CC791BFE49700052747C /* ChatInputItemViewTests.swift */,
-				C3C0CC7A1BFE49700052747C /* ChatInputManagerTests.swift */,
+				C3C0CC7A1BFE49700052747C /* ChatInputPresenterTests.swift */,
 				C3C0CC7B1BFE49700052747C /* LiveCameraCellTests.swift */,
 				C3C0CC7C1BFE49700052747C /* PhotosChatInputItemTests.swift */,
 				C3C0CC7D1BFE49700052747C /* PhotosInputViewItemSizeCalculatorTests.swift */,
@@ -614,7 +614,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				C3C0CC861BFE49700052747C /* ChatInputItemTests.swift in Sources */,
-				C3C0CC881BFE49700052747C /* ChatInputManagerTests.swift in Sources */,
+				C3C0CC881BFE49700052747C /* ChatInputPresenterTests.swift in Sources */,
 				C3815D001C036B3000DF95CA /* PhotoMessagePresenterBuilderTests.swift in Sources */,
 				C3C0CC891BFE49700052747C /* LiveCameraCellTests.swift in Sources */,
 				C35FE3C51C0331CF00D42980 /* TextMessagePresenterTests.swift in Sources */,

--- a/ChattoAdditions/Source/Input/ChatInputBar.swift
+++ b/ChattoAdditions/Source/Input/ChatInputBar.swift
@@ -35,6 +35,7 @@ protocol ChatInputBarDelegate: class {
 public class ChatInputBar: ReusableXibView {
 
     weak var delegate: ChatInputBarDelegate?
+    weak var presenter: ChatInputBarPresenter?
 
     @IBOutlet weak var scrollView: HorizontalStackScrollView!
     @IBOutlet weak var textView: ExpandableTextView!
@@ -148,15 +149,14 @@ public class ChatInputBar: ReusableXibView {
     }
 
     @IBAction func buttonTapped(sender: AnyObject) {
-        self.delegate?.inputBarSendButtonPressed(self)
-        self.inputText = ""
+        self.presenter?.onSendButtonPressed()
     }
 }
 
 // MARK: - ChatInputItemViewDelegate
 extension ChatInputBar: ChatInputItemViewDelegate {
     func inputItemViewTapped(view: ChatInputItemView) {
-        self.delegate?.inputBar(self, didReceiveFocusOnItem: view.inputItem)
+        self.presenter?.onDidReceiveFocusOnItem(view.inputItem)
     }
 }
 
@@ -195,11 +195,11 @@ extension ChatInputBar { // Tabar
 // MARK: UITextViewDelegate
 extension ChatInputBar: UITextViewDelegate {
     public func textViewDidEndEditing(textView: UITextView) {
-        self.delegate?.inputBarDidEndEditing(self)
+        self.presenter?.onDidEndEditing()
     }
 
     public func textViewDidBeginEditing(textView: UITextView) {
-        self.delegate?.inputBarDidBeginEditing(self)
+        self.presenter?.onDidBeginEditing()
     }
 
     public func textViewDidChange(textView: UITextView) {
@@ -215,5 +215,4 @@ class SingleViewContainerView: UIView {
             return CGSize.zero
         }
     }
-
 }

--- a/ChattoAdditions/Source/Input/ChatInputBar.swift
+++ b/ChattoAdditions/Source/Input/ChatInputBar.swift
@@ -27,6 +27,7 @@ import UIKit
 protocol ChatInputBarDelegate: class {
     func inputBarDidBeginEditing(inputBar: ChatInputBar)
     func inputBarDidEndEditing(inputBar: ChatInputBar)
+    func inputBarDidChangeText(inputBar: ChatInputBar)
     func inputBarSendButtonPressed(inputBar: ChatInputBar)
     func inputBar(inputBar: ChatInputBar, didReceiveFocusOnItem item: ChatInputItemProtocol)
 }
@@ -150,6 +151,7 @@ public class ChatInputBar: ReusableXibView {
 
     @IBAction func buttonTapped(sender: AnyObject) {
         self.presenter?.onSendButtonPressed()
+        self.delegate?.inputBarSendButtonPressed(self)
     }
 }
 
@@ -157,6 +159,7 @@ public class ChatInputBar: ReusableXibView {
 extension ChatInputBar: ChatInputItemViewDelegate {
     func inputItemViewTapped(view: ChatInputItemView) {
         self.presenter?.onDidReceiveFocusOnItem(view.inputItem)
+        self.delegate?.inputBar(self, didReceiveFocusOnItem: view.inputItem)
     }
 }
 
@@ -196,14 +199,17 @@ extension ChatInputBar { // Tabar
 extension ChatInputBar: UITextViewDelegate {
     public func textViewDidEndEditing(textView: UITextView) {
         self.presenter?.onDidEndEditing()
+        self.delegate?.inputBarDidEndEditing(self)
     }
 
     public func textViewDidBeginEditing(textView: UITextView) {
         self.presenter?.onDidBeginEditing()
+        self.delegate?.inputBarDidBeginEditing(self)
     }
 
     public func textViewDidChange(textView: UITextView) {
         self.sendButton.enabled = !textView.text.isEmpty
+        self.delegate?.inputBarDidChangeText(self)
     }
 }
 

--- a/ChattoAdditions/Source/Input/ChatInputBar.swift
+++ b/ChattoAdditions/Source/Input/ChatInputBar.swift
@@ -24,7 +24,7 @@
 
 import UIKit
 
-protocol ChatInputBarDelegate: class {
+public protocol ChatInputBarDelegate: class {
     func inputBarDidBeginEditing(inputBar: ChatInputBar)
     func inputBarDidEndEditing(inputBar: ChatInputBar)
     func inputBarDidChangeText(inputBar: ChatInputBar)
@@ -35,7 +35,7 @@ protocol ChatInputBarDelegate: class {
 @objc
 public class ChatInputBar: ReusableXibView {
 
-    weak var delegate: ChatInputBarDelegate?
+    public weak var delegate: ChatInputBarDelegate?
     weak var presenter: ChatInputBarPresenter?
 
     @IBOutlet weak var scrollView: HorizontalStackScrollView!

--- a/ChattoAdditions/Tests/Input/ChatInputBarTests.swift
+++ b/ChattoAdditions/Tests/Input/ChatInputBarTests.swift
@@ -27,15 +27,14 @@ import XCTest
 
 class ChatInputBarTests: XCTestCase {
     private var bar: ChatInputBar!
-    private var delegate: MockChatInputBarDelegate!
+    private var presenter: FakeChatInputBarPresenter!
     override func setUp() {
         super.setUp()
         self.bar = ChatInputBar.loadNib()
     }
 
-    private func setupDelegate() {
-        self.delegate = MockChatInputBarDelegate()
-        self.bar.delegate = self.delegate
+    private func setupPresenter() {
+        self.presenter = FakeChatInputBarPresenter(chatInputBar: self.bar)
     }
 
     private func createItemView(inputItem: ChatInputItemProtocol) -> ChatInputItemView {
@@ -56,26 +55,26 @@ class ChatInputBarTests: XCTestCase {
         XCTAssertFalse(self.bar.sendButton.enabled)
     }
 
-    // MARK: - Delegation tests
-    func testThat_WhenItemViewTapped_ItNotifiesDelegateThatNewItemReceivedFocus() {
-        self.setupDelegate()
+    // MARK: - Presenter tests
+    func testThat_WhenItemViewTapped_ItNotifiesPresenterThatNewItemReceivedFocus() {
+        self.setupPresenter()
         let item = MockInputItem()
         self.bar.inputItemViewTapped(createItemView(item))
 
-        XCTAssertTrue(self.delegate.itemDidReceiveFocus)
-        XCTAssertTrue(self.delegate.itemThatReceivedFocus === item)
+        XCTAssertTrue(self.presenter.onDidReceiveFocusOnItemCalled)
+        XCTAssertTrue(self.presenter.itemThatReceivedFocus === item)
     }
 
-    func testThat_WhenTextViewDidBeginEditing_ItNotifiesDelegate() {
-        self.setupDelegate()
+    func testThat_WhenTextViewDidBeginEditing_ItNotifiesPresenter() {
+        self.setupPresenter()
         self.bar.textViewDidBeginEditing(self.bar.textView)
-        XCTAssertTrue(self.delegate.inputBarDidBeginEditing)
+        XCTAssertTrue(self.presenter.onDidBeginEditingCalled)
     }
 
-    func testThat_WhenTextViewDidEndEditing_ItNotifiesDelegate() {
-        self.setupDelegate()
+    func testThat_WhenTextViewDidEndEditing_ItNotifiesPresenter() {
+        self.setupPresenter()
         self.bar.textViewDidEndEditing(self.bar.textView)
-        XCTAssertTrue(self.delegate.inputBarDidEndEditing)
+        XCTAssertTrue(self.presenter.onDidEndEditingCalled)
     }
 
     func testThat_GivenTextViewHasNoText_WhenTextViewDidChange_ItDisablesSendButton() {
@@ -96,33 +95,39 @@ class ChatInputBarTests: XCTestCase {
         XCTAssertTrue(self.bar.sendButton.enabled)
     }
 
-    func testThat_WhenSendButtonTapped_ItNotifiesDelegate() {
-        self.setupDelegate()
+    func testThat_WhenSendButtonTapped_ItNotifiesPresenter() {
+        self.setupPresenter()
         self.bar.buttonTapped(self.bar)
-        XCTAssertTrue(self.delegate.inputBarSendButtonPressed)
+        XCTAssertTrue(self.presenter.onSendButtonPressedCalled)
     }
 }
 
-class MockChatInputBarDelegate: ChatInputBarDelegate {
-    var inputBarDidBeginEditing = false
-    func inputBarDidBeginEditing(inputBar: ChatInputBar) {
-        self.inputBarDidBeginEditing = true
+class FakeChatInputBarPresenter: ChatInputBarPresenter {
+    let chatInputBar: ChatInputBar
+    init(chatInputBar: ChatInputBar) {
+        self.chatInputBar = chatInputBar
+        self.chatInputBar.presenter = self
     }
 
-    var inputBarDidEndEditing = false
-    func inputBarDidEndEditing(inputBar: ChatInputBar) {
-        self.inputBarDidEndEditing = true
+    var onDidBeginEditingCalled = false
+    func onDidBeginEditing() {
+        self.onDidBeginEditingCalled = true
     }
 
-    var inputBarSendButtonPressed = false
-    func inputBarSendButtonPressed(inputBar: ChatInputBar) {
-        self.inputBarSendButtonPressed = true
+    var onDidEndEditingCalled = false
+    func onDidEndEditing() {
+        self.onDidEndEditingCalled = true
     }
 
-    var itemDidReceiveFocus = false
+    var onSendButtonPressedCalled = false
+    func onSendButtonPressed() {
+        self.onSendButtonPressedCalled = true
+    }
+
+    var onDidReceiveFocusOnItemCalled = false
     var itemThatReceivedFocus: ChatInputItemProtocol?
-    func inputBar(inputBar: ChatInputBar, didReceiveFocusOnItem item: ChatInputItemProtocol) {
-        self.itemDidReceiveFocus = true
+    func onDidReceiveFocusOnItem(item: ChatInputItemProtocol) {
+        self.onDidReceiveFocusOnItemCalled = true
         self.itemThatReceivedFocus = item
     }
 }

--- a/ChattoAdditions/Tests/Input/ChatInputManagerTests.swift
+++ b/ChattoAdditions/Tests/Input/ChatInputManagerTests.swift
@@ -27,62 +27,68 @@ import XCTest
 
 class ChatInputManagerTests: XCTestCase {
     private var bar: ChatInputBar!
-    private var presenter: ChatInputBarPresenter!
+    private var presenter: BasicChatInputBarPresenter!
     override func setUp() {
         super.setUp()
         self.bar = ChatInputBar.loadNib()
-        self.presenter = ChatInputBarPresenter(chatInputView: self.bar, chatInputItems: [])
+        self.presenter = BasicChatInputBarPresenter(chatInputBar: self.bar, chatInputItems: [])
+    }
+
+    func testThat_WhenSendButtonPressed_InputTextBecomesEmpty() {
+        self.bar.inputText = "text"
+        self.presenter.onSendButtonPressed()
+        XCTAssertEqual(self.bar.inputText.characters.count, 0)
     }
 
     // MARK: - Focused item tests
     func testThat_WhenItemDidReceiveFocus_ItemBecomesFocused() {
         let item = MockInputItem() as ChatInputItemProtocol
-        self.presenter.inputBar(self.bar, didReceiveFocusOnItem: item)
+        self.presenter.onDidReceiveFocusOnItem(item)
         XCTAssertTrue(self.presenter.focusedItem! === item)
     }
 
     func testThat_WhenAnotherItemDidReceiveFocus_AnotherItemBecomesFocused() {
         let item = MockInputItem()
-        self.presenter.inputBar(self.bar, didReceiveFocusOnItem: item)
+        self.presenter.onDidReceiveFocusOnItem(item)
 
         let anotherItem = MockInputItem() as ChatInputItemProtocol
-        self.presenter.inputBar(self.bar, didReceiveFocusOnItem: anotherItem)
+        self.presenter.onDidReceiveFocusOnItem(anotherItem)
         XCTAssertTrue(self.presenter.focusedItem! === anotherItem)
     }
 
     func testThat_GivenItemHasNonePresentationMode_WhenItemReceivesFocus_ItDoesntBecomeFocused() {
         let item = MockInputItem()
         item.presentationMode = .None
-        self.presenter.inputBar(self.bar, didReceiveFocusOnItem: item)
+        self.presenter.onDidReceiveFocusOnItem(item)
         XCTAssertNil(self.presenter.focusedItem)
     }
 
     func testThat_WhenItemReceivesFocus_ItBecomesSelected() {
         let item = MockInputItem()
-        self.presenter.inputBar(self.bar, didReceiveFocusOnItem: item)
+        self.presenter.onDidReceiveFocusOnItem(item)
         XCTAssertTrue(item.selected)
     }
 
     func testThat_WhenAnotherItemReceivesFocus_PreviousItemBecomesDeselected() {
         let item = MockInputItem()
-        self.presenter.inputBar(self.bar, didReceiveFocusOnItem: item)
+        self.presenter.onDidReceiveFocusOnItem(item)
 
         let anotherItem = MockInputItem()
-        self.presenter.inputBar(self.bar, didReceiveFocusOnItem: anotherItem)
+        self.presenter.onDidReceiveFocusOnItem(anotherItem)
         XCTAssertFalse(item.selected)
     }
 
     func testThat_GivenItemShowsSendButton_WhenItemReceivesFocus_PresenterShowsSendButton() {
         let item = MockInputItem()
         item.showsSendButton = true
-        self.presenter.inputBar(self.bar, didReceiveFocusOnItem: item)
+        self.presenter.onDidReceiveFocusOnItem(item)
         XCTAssertTrue(self.bar.showsSendButton)
     }
 
     func testThat_GivenItemDoesntShowSendButton_WhenItemReceivesFocus_PresenterHidesSendButton() {
         self.bar.showsSendButton = true
         let item = MockInputItem()
-        self.presenter.inputBar(self.bar, didReceiveFocusOnItem: item)
+        self.presenter.onDidReceiveFocusOnItem(item)
         XCTAssertFalse(self.bar.showsSendButton)
     }
 
@@ -90,7 +96,7 @@ class ChatInputManagerTests: XCTestCase {
         self.bar.showsTextView = false
         let item = MockInputItem()
         item.presentationMode = .Keyboard
-        self.presenter.inputBar(self.bar, didReceiveFocusOnItem: item)
+        self.presenter.onDidReceiveFocusOnItem(item)
         XCTAssertTrue(self.bar.showsTextView)
     }
 
@@ -98,7 +104,7 @@ class ChatInputManagerTests: XCTestCase {
         self.bar.showsTextView = true
         let item = MockInputItem()
         item.presentationMode = .CustomView
-        self.presenter.inputBar(self.bar, didReceiveFocusOnItem: item)
+        self.presenter.onDidReceiveFocusOnItem(item)
         XCTAssertFalse(self.bar.showsTextView)
     }
 
@@ -106,18 +112,18 @@ class ChatInputManagerTests: XCTestCase {
         self.bar.showsTextView = true
         let item = MockInputItem()
         item.presentationMode = .None
-        self.presenter.inputBar(self.bar, didReceiveFocusOnItem: item)
+        self.presenter.onDidReceiveFocusOnItem(item)
         XCTAssertTrue(self.bar.showsTextView)
 
     }
 
     func testThat_GivenPresenterHasFocusedItem_WhenSendButtonPressed_FocusedItemHandlesInputFromInputBar() {
         let item = MockInputItem()
-        self.presenter.inputBar(self.bar, didReceiveFocusOnItem: item)
+        self.presenter.onDidReceiveFocusOnItem(item)
 
         let inputText = "inputText"
         self.bar.inputText = inputText
-        self.presenter.inputBarSendButtonPressed(self.bar)
+        self.presenter.onSendButtonPressed()
 
         XCTAssertTrue(item.handledInput as! String == inputText)
     }
@@ -135,35 +141,35 @@ class ChatInputManagerTests: XCTestCase {
         }
 
         let inputItems: Array<ChatInputItemProtocol> = [firstInputItem, secondInputItem]
-        self.presenter = ChatInputBarPresenter(chatInputView: self.bar, chatInputItems: inputItems)
-        self.presenter.inputBarSendButtonPressed(self.bar)
+        self.presenter = BasicChatInputBarPresenter(chatInputBar: self.bar, chatInputItems: inputItems)
+        self.presenter.onSendButtonPressed()
         XCTAssertEqual(itemThatHandledInput, 1)
     }
 
     // MARK: - Bar editing tests
     func testThat_GivenPresenterHasFocusedItem_WhenBarDidEndEditing_FocusedItemLostFocus() {
         let item = MockInputItem()
-        self.presenter.inputBar(self.bar, didReceiveFocusOnItem: item)
-        self.presenter.inputBarDidEndEditing(self.bar)
+        self.presenter.onDidReceiveFocusOnItem(item)
+        self.presenter.onDidEndEditing()
         XCTAssertNil(self.presenter.focusedItem)
     }
 
     func testThat_WhenBarDidEndEditing_PresenterShowsSendButton() {
         self.bar.showsSendButton = false
-        self.presenter.inputBarDidEndEditing(self.bar)
+        self.presenter.onDidEndEditing()
         XCTAssertTrue(self.bar.showsSendButton)
     }
 
     func testThat_WhenBarDidEndEditing_PresenterShowsTextView() {
         self.bar.showsTextView = false
-        self.presenter.inputBarDidEndEditing(self.bar)
+        self.presenter.onDidEndEditing()
         XCTAssertTrue(self.bar.showsTextView)
     }
 
     func testThat_GivenPresenterHasNoFocusedItem_WhenBarDidBeginEditing_FirstKeyboardItemBecomesFocused() {
         let inputItems: Array<ChatInputItemProtocol> = [TextChatInputItem(), TextChatInputItem()]
-        self.presenter = ChatInputBarPresenter(chatInputView: self.bar, chatInputItems: inputItems)
-        self.presenter.inputBarDidBeginEditing(self.bar)
+        self.presenter = BasicChatInputBarPresenter(chatInputBar: self.bar, chatInputItems: inputItems)
+        self.presenter.onDidBeginEditing()
         XCTAssertTrue(self.presenter.focusedItem! === inputItems[0])
     }
 }

--- a/ChattoAdditions/Tests/Input/ChatInputPresenterTests.swift
+++ b/ChattoAdditions/Tests/Input/ChatInputPresenterTests.swift
@@ -25,7 +25,7 @@
 import XCTest
 @testable import ChattoAdditions
 
-class ChatInputManagerTests: XCTestCase {
+class ChatInputPresenterTests: XCTestCase {
     private var bar: ChatInputBar!
     private var presenter: BasicChatInputBarPresenter!
     override func setUp() {

--- a/ChattoApp/ChattoApp/Source/DemoChatViewController.swift
+++ b/ChattoApp/ChattoApp/Source/DemoChatViewController.swift
@@ -52,11 +52,11 @@ class DemoChatViewController: BaseChatViewController {
         self.dataSource.addRandomIncomingMessage()
     }
 
-    var chatInputPresenter: ChatInputBarPresenter!
+    var chatInputPresenter: BasicChatInputBarPresenter!
     override func createChatInputView() -> UIView {
         let chatInputView = ChatInputBar.loadNib()
         self.configureChatInputBar(chatInputView)
-        self.chatInputPresenter = ChatInputBarPresenter(chatInputView: chatInputView, chatInputItems: self.createChatInputItems())
+        self.chatInputPresenter = BasicChatInputBarPresenter(chatInputBar: chatInputView, chatInputItems: self.createChatInputItems())
         return chatInputView
     }
 


### PR DESCRIPTION
ChatInputBarDelegate has been used for internal purposes, but now it purpose is to notify external users about UI events (requested in #40). ChatInputBar notifies its presenter using direct method calls (classic MVP pattern) instead of using delegation pattern.