### PR TITLE
Make several properties in PhotoMessagePresenterBuilder public

### DIFF
--- a/ChattoAdditions/Source/Chat Items/PhotoMessages/PhotoMessagePresenter.swift
+++ b/ChattoAdditions/Source/Chat Items/PhotoMessages/PhotoMessagePresenter.swift
@@ -72,7 +72,7 @@ public class PhotoMessagePresenter<ViewModelBuilderT, InteractionHandlerT where
         return viewModel
     }
 
-    var photoCell: PhotoMessageCollectionViewCell? {
+    public var photoCell: PhotoMessageCollectionViewCell? {
         if let cell = self.cell {
             if let photoCell = cell as? PhotoMessageCollectionViewCell {
                 return photoCell

--- a/ChattoAdditions/Source/Chat Items/PhotoMessages/PhotoMessagePresenterBuilder.swift
+++ b/ChattoAdditions/Source/Chat Items/PhotoMessages/PhotoMessagePresenterBuilder.swift
@@ -41,8 +41,8 @@ public class PhotoMessagePresenterBuilder<ViewModelBuilderT, InteractionHandlerT
             self.interactionHandler = interactionHandler
     }
 
-    let viewModelBuilder: ViewModelBuilderT
-    let interactionHandler: InteractionHandlerT?
+    public let viewModelBuilder: ViewModelBuilderT
+    public let interactionHandler: InteractionHandlerT?
     public lazy var sizingCell: PhotoMessageCollectionViewCell = PhotoMessageCollectionViewCell.sizingCell()
     public lazy var photoCellStyle: PhotoMessageCollectionViewCellStyleProtocol = PhotoMessageCollectionViewCellDefaultStyle()
     public lazy var baseCellStyle: BaseMessageCollectionViewCellStyleProtocol = BaseMessageCollectionViewCellDefaultSyle()


### PR DESCRIPTION
As a user you are able to make subclass of PhotoMessagePresenterBuilder, but you don't have access to several properties that was initialized using public init method.