### PR TITLE
Implement ChatInputItemProtocol directly, rather then through class extension

### DIFF
--- a/ChattoAdditions/Source/Input/Photos/PhotosChatInputItem.swift
+++ b/ChattoAdditions/Source/Input/Photos/PhotosChatInputItem.swift
@@ -38,7 +38,7 @@ public struct ButtonImages {
     }
 }
 
-public class PhotosChatInputItem {
+public class PhotosChatInputItem: ChatInputItemProtocol {
     typealias Class = PhotosChatInputItem
 
     public var photoInputHandler: ((UIImage) -> Void)?
@@ -83,10 +83,9 @@ public class PhotosChatInputItem {
             }
         }
     }
-}
 
-// MARK: - ChatInputItemProtocol
-extension PhotosChatInputItem : ChatInputItemProtocol {
+    // MARK: - ChatInputItemProtocol
+
     public var presentationMode: ChatInputItemPresentationMode {
         return .CustomView
     }


### PR DESCRIPTION
ChatInputItemProtocol protocol should be implemented within PhotosChatInputItem class definition, so it can be overridden in subclasses. Swift doesn't allow to override methods in extensions **yet!**