### PR TITLE
Fixes for offset/insets adjustements

### DIFF
--- a/Chatto/Source/ChatController/KeyboardTracker.swift
+++ b/Chatto/Source/ChatController/KeyboardTracker.swift
@@ -122,7 +122,7 @@ class KeyboardTracker {
 
     private func bottomConstraintFromTrackingView() -> CGFloat {
         let trackingViewRect = self.view.convertRect(self.keyboardTrackerView.bounds, fromView: self.keyboardTrackerView)
-        return  self.view.bounds.height - trackingViewRect.maxY
+        return max(0, self.view.bounds.height - trackingViewRect.maxY)
     }
 
     func layoutTrackingViewIfNeeded() {


### PR DESCRIPTION
This fixes:
 - Hiding navigation bar programmatically doesn't adjust content offset properly
 - Hiding keyboard programmatically when scroll position is at the top results in the first cell being scrolled  in the middle of the screen