### PR TITLE
Allows to control whether setting the dataSource enqueues an update immediately

### DIFF
--- a/Chatto/Source/ChatController/BaseChatViewController.swift
+++ b/Chatto/Source/ChatController/BaseChatViewController.swift
@@ -40,11 +40,23 @@ public class BaseChatViewController: UIViewController, UICollectionViewDataSourc
     public var constants = Constants()
 
     public private(set) var collectionView: UICollectionView!
-    public internal(set) var chatItemCompanionCollection: ChatItemCompanionCollection = ReadOnlyOrderedDictionary(items: [])
-    public var chatDataSource: ChatDataSourceProtocol? {
-        didSet {
-            self.chatDataSource?.delegate = self
-            self.enqueueModelUpdate(updateType: .Reload)
+    public final internal(set) var chatItemCompanionCollection: ChatItemCompanionCollection = ReadOnlyOrderedDictionary(items: [])
+    private var _chatDataSource: ChatDataSourceProtocol?
+    public final var chatDataSource: ChatDataSourceProtocol? {
+        get {
+            return _chatDataSource
+        }
+        set {
+            self.setChatDataSource(newValue, triggeringUpdateType: .Normal)
+        }
+    }
+
+    // Custom update on setting the data source. if triggeringUpdateType is nil it won't enqueue any update (you should do it later manually)
+    public final func setChatDataSource(dataSource: ChatDataSourceProtocol?, triggeringUpdateType updateType: UpdateType?) {
+        self._chatDataSource = dataSource
+        self._chatDataSource?.delegate = self
+        if let updateType = updateType {
+            self.enqueueModelUpdate(updateType: updateType)
         }
     }
 

--- a/ChattoApp/ChattoApp/Source/DemoChatViewController.swift
+++ b/ChattoApp/ChattoApp/Source/DemoChatViewController.swift
@@ -32,6 +32,7 @@ class DemoChatViewController: BaseChatViewController {
     var dataSource: FakeDataSource! {
         didSet {
             self.chatDataSource = self.dataSource
+            self.chatDataSourceDidUpdate(self.dataSource)
         }
     }
 


### PR DESCRIPTION
This allows to make it manually and save a model update which can speed up loading the conversation.