### PR TITLE
Fixed iOS 8 crash

### DIFF
--- a/Chatto/Source/ChatController/Collaborators/KeyboardTracker.swift
+++ b/Chatto/Source/ChatController/Collaborators/KeyboardTracker.swift
@@ -155,7 +155,7 @@ class KeyboardTracker {
         guard self.isTracking && self.keyboardStatus == .Shown else { return }
         let newBottomConstraint = self.bottomConstraintFromTrackingView()
         self.inputContainerBottomConstraint.constant = newBottomConstraint
-        self.view.layoutIfNeeded()
+        self.view.setNeedsLayout()
     }
 }
 


### PR DESCRIPTION
- Use an iOS8 device
- Go to a conversation
- Tap on textfield to open keyboard
- Press return multiple times so textfield goes under header (or write a long message)

AR: Crash