### PR TITLE
Fixes some keyboard issues

### DIFF
--- a/Chatto/Source/ChatController/BaseChatViewController.swift
+++ b/Chatto/Source/ChatController/BaseChatViewController.swift
@@ -144,7 +144,7 @@ public class BaseChatViewController: UIViewController, UICollectionViewDataSourc
         super.viewDidLayoutSubviews()
 
         self.adjustCollectionViewInsets()
-        self.keyboardTracker.layoutTrackingViewIfNeeded()
+        self.keyboardTracker.adjustTrackingViewSizeIfNeeded()
 
         if self.isFirstLayout {
             self.updateQueue.start()

--- a/ChattoAdditions/Source/Input/ExpandableTextView.swift
+++ b/ChattoAdditions/Source/Input/ExpandableTextView.swift
@@ -93,11 +93,21 @@ public class ExpandableTextView: UITextView {
     func textDidChange() {
         self.updatePlaceholderVisibility()
         self.scrollToCaret()
+
+        if #available(iOS 9, *) {
+            // Bugfix:
+            // 1. Open keyboard
+            // 2. Paste very long text (so it snaps to nav bar and shows scroll indicators)
+            // 3. Select all and cut
+            // 4. Paste again: Texview it's smaller than it should be
+            self.scrollEnabled = false
+            self.scrollEnabled = true
+        }
     }
 
     private func scrollToCaret() {
-        if selectedTextRange != nil {
-            var rect = caretRectForPosition(self.selectedTextRange!.end)
+        if let textRange = self.selectedTextRange {
+            var rect = caretRectForPosition(textRange.end)
             rect = CGRect(origin: rect.origin, size: CGSize(width: rect.width, height: rect.height + textContainerInset.bottom))
 
             self.scrollRectToVisible(rect, animated: false)
@@ -105,7 +115,7 @@ public class ExpandableTextView: UITextView {
     }
 
     private func updatePlaceholderVisibility() {
-        if text == "" {
+        if self.text == "" {
             self.showPlaceholder()
         } else {
             self.hidePlaceholder()
@@ -113,7 +123,7 @@ public class ExpandableTextView: UITextView {
     }
 
     private func showPlaceholder() {
-        self.addSubview(placeholder)
+        self.addSubview(self.placeholder)
     }
 
     private func hidePlaceholder() {


### PR DESCRIPTION
**Fixes:**
A)
1. Go to a chat conversation
2. Tap on textfield to open keyboard
3. Press return multiple times (until the textfield grows enough to show scroll indicators, and touches the navigation bar)
4. Reveal/Hide the predictive text bar above the keyboard

iOS 8: Keyboard moves up and down
iOS 9: App hangs due to infinite layout loop

B)
Steps as in A)
iOS 8: Keyboard jumps and creates a small gap at the bottom of the screen.
iOS 9: Cursor jumps slightly (**not fixed**)

C)
1. Go to a chat conversation
2. Tap on textfield to open keyboard
3. Paste a very long text (so textfield grows enough to show scroll indicators, and touches the navigation bar)
4. Select all text and remove
5. Paste again

iOS 8: Broken position for keyboard + textfield. Keyboard and textfield may appear in the middle of the screen for example
iOS 9: Broken textfield. It is not scrollable and can only see part of text. If you edit the text (remove a letter), then it fixes the issue and you can now scroll.

D)
1. Go to a chat conversation
2. Tap on textfield to open keyboard
3. Open Chinese (Traditional) - Zhuyin keyboard
4. Open full-screen chinese keyboard ( tap on ^ )
5. Drag the keyboard down by swiping down

Full-screen chinese keyboard will be misplaced with close arrow ( v ) not visible

**Other related issues not fixed here**

E)
1. Go to a chat conversation
2. Tap on textfield to open keyboard
3. Paste very long text (so textfield grows enough to show scroll indicators, and touches the navigation bar)
3. Open Chinese (Traditional) - Zhuyin keyboard
4. Open full-screen chinese keyboard ( tap on ^ )
5. Drag the keyboard down by swiping down

Full-screen chinese keyboard will be misplaced. It will be in the middle of the screen ( looks like as much as the textfield grows once it's placed at the bottom )

F) 
1. Go to a chat conversation
2. Tap on textfield to open keyboard
3. Long press on a text message with a date
4. Choose "Create event" from action sheet
5. In the create event screen dismiss the keyboard
6. Cancel event creation

Input field is placed in the middle of the screen



