### PR TITLE
Added support for embedding in UITabBarController

### DIFF
--- a/Chatto/Source/ChatController/BaseChatViewController.swift
+++ b/Chatto/Source/ChatController/BaseChatViewController.swift
@@ -139,7 +139,7 @@ public class BaseChatViewController: UIViewController, UICollectionViewDataSourc
         let layoutBlock = { [weak self] (bottomMargin: CGFloat) in
             guard let sSelf = self else { return }
             sSelf.isAdjustingInputContainer = true
-            sSelf.inputContainerBottomConstraint.constant = bottomMargin
+            sSelf.inputContainerBottomConstraint.constant = max(bottomMargin, sSelf.bottomLayoutGuide.length)
             sSelf.view.layoutIfNeeded()
             sSelf.isAdjustingInputContainer = false
         }
@@ -160,6 +160,7 @@ public class BaseChatViewController: UIViewController, UICollectionViewDataSourc
         if self.isFirstLayout {
             self.updateQueue.start()
             self.isFirstLayout = false
+            self.inputContainerBottomConstraint.constant = self.bottomLayoutGuide.length
         }
     }
 

--- a/ChattoApp/ChattoApp/Base.lproj/Main.storyboard
+++ b/ChattoApp/ChattoApp/Base.lproj/Main.storyboard
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="9531" systemVersion="15C47a" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="D7z-rL-VE6">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="10116" systemVersion="15E65" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="D7z-rL-VE6">
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="9529"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="10085"/>
     </dependencies>
     <scenes>
         <!--Navigation Controller-->
@@ -36,11 +36,11 @@
                                         <rect key="frame" x="0.0" y="64" width="600" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="0MQ-Mb-P7s" id="Ypa-vB-cbx">
-                                            <rect key="frame" x="0.0" y="0.0" width="600" height="43.5"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="600" height="43"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" text="Overview" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="jal-kA-we8">
-                                                    <rect key="frame" x="15" y="0.0" width="570" height="43.5"/>
+                                                    <rect key="frame" x="15" y="0.0" width="570" height="43"/>
                                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="16"/>
                                                     <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
@@ -56,11 +56,11 @@
                                         <rect key="frame" x="0.0" y="108" width="600" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="X2A-JR-aec" id="DZz-aG-p6V">
-                                            <rect key="frame" x="0.0" y="0.0" width="600" height="43.5"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="600" height="43"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" text="Empty chat" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="eCF-Cr-RcE">
-                                                    <rect key="frame" x="15" y="0.0" width="570" height="43.5"/>
+                                                    <rect key="frame" x="15" y="0.0" width="570" height="43"/>
                                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="16"/>
                                                     <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
@@ -76,11 +76,11 @@
                                         <rect key="frame" x="0.0" y="152" width="600" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="dA1-w8-ALD" id="d0t-x4-o55">
-                                            <rect key="frame" x="0.0" y="0.0" width="600" height="43.5"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="600" height="43"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" text="Chat with 2 messages" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="RO7-aN-oRH">
-                                                    <rect key="frame" x="15" y="0.0" width="570" height="43.5"/>
+                                                    <rect key="frame" x="15" y="0.0" width="570" height="43"/>
                                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="16"/>
                                                     <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
@@ -89,18 +89,18 @@
                                             </subviews>
                                         </tableViewCellContentView>
                                         <connections>
-                                            <segue destination="QHk-uH-HdW" kind="show" identifier="2 messages" id="XTb-3m-hGN"/>
+                                            <segue destination="SUy-Fa-YaG" kind="show" identifier="2 messages" id="b4V-0i-f22"/>
                                         </connections>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" textLabel="vfg-B4-o6w" style="IBUITableViewCellStyleDefault" id="V9u-B3-sad">
                                         <rect key="frame" x="0.0" y="196" width="600" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="V9u-B3-sad" id="gj3-MN-So4">
-                                            <rect key="frame" x="0.0" y="0.0" width="600" height="43.5"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="600" height="43"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" text="Chat with 10000 messages" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="vfg-B4-o6w">
-                                                    <rect key="frame" x="15" y="0.0" width="570" height="43.5"/>
+                                                    <rect key="frame" x="15" y="0.0" width="570" height="43"/>
                                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="16"/>
                                                     <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
@@ -145,8 +145,45 @@
             </objects>
             <point key="canvasLocation" x="563" y="673"/>
         </scene>
+        <!--Chat-->
+        <scene sceneID="XZV-5d-Ll9">
+            <objects>
+                <viewController id="MxS-1F-D0s" customClass="DemoChatViewController" customModule="ChattoApp" customModuleProvider="target" sceneMemberID="viewController">
+                    <layoutGuides>
+                        <viewControllerLayoutGuide type="top" id="ip0-ZP-cfM"/>
+                        <viewControllerLayoutGuide type="bottom" id="5au-gY-3hB"/>
+                    </layoutGuides>
+                    <view key="view" contentMode="scaleToFill" id="ZQf-vf-C9w">
+                        <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                    </view>
+                    <tabBarItem key="tabBarItem" title="Item" id="yRn-WO-1kA"/>
+                    <navigationItem key="navigationItem" title="Chat" id="hTD-1i-epO"/>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="Ue1-ep-k2K" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="1341" y="1542"/>
+        </scene>
+        <!--Tab Bar Controller-->
+        <scene sceneID="Amt-he-gQ5">
+            <objects>
+                <tabBarController automaticallyAdjustsScrollViewInsets="NO" id="SUy-Fa-YaG" sceneMemberID="viewController">
+                    <toolbarItems/>
+                    <tabBar key="tabBar" contentMode="scaleToFill" id="ozs-Zv-IKt">
+                        <autoresizingMask key="autoresizingMask"/>
+                        <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
+                    </tabBar>
+                    <connections>
+                        <segue destination="MxS-1F-D0s" kind="relationship" relationship="viewControllers" id="5BN-Lc-FcT"/>
+                    </connections>
+                </tabBarController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="dHC-O4-ZBi" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="529" y="1542"/>
+        </scene>
     </scenes>
     <inferredMetricsTieBreakers>
-        <segue reference="uYC-Cg-TnO"/>
+        <segue reference="8Ld-Nt-cKX"/>
     </inferredMetricsTieBreakers>
 </document>

--- a/ChattoApp/ChattoApp/Source/ConversationsViewController.swift
+++ b/ChattoApp/ChattoApp/Source/ConversationsViewController.swift
@@ -44,7 +44,18 @@ class ConversationsViewController: UITableViewController {
             assert(false, "segue not handled!")
         }
 
-        let chatController = segue.destinationViewController as! DemoChatViewController
+
+        let chatController = { () -> DemoChatViewController? in
+            if let controller = segue.destinationViewController as? DemoChatViewController {
+                return controller
+            }
+            if let tabController = segue.destinationViewController as? UITabBarController,
+                controller = tabController.viewControllers?.first as? DemoChatViewController {
+                return controller
+            }
+            return nil
+        }()!
+
         if dataSource == nil {
             dataSource = FakeDataSource(count: initialCount, pageSize: pageSize)
         }


### PR DESCRIPTION
Fixes: #120

Before the input bar would go behind the transparent UITTabBar. By respecting the bottom layout guide the chat view controller supports this and anything else that might add transparent UI to the bottom of the window.

I have modified one of the demos to embed inside a UITabBarController to make this easier to test and ensure it keeps working.

[Here is a gif!](https://dl.dropboxusercontent.com/s/5zjwlirjtogdrz9/Jeff%20Recording%20-%20May%2012%2C%202016%2C%208.09.39.53%20AM.gif?dl=0)