### PR TITLE
Allows the decorator to override item ids

### DIFF
--- a/Chatto/Source/Chat Items/ChatItemCompanion.swift
+++ b/Chatto/Source/Chat Items/ChatItemCompanion.swift
@@ -28,20 +28,25 @@ public protocol ChatItemsDecoratorProtocol {
     func decorateItems(chatItems: [ChatItemProtocol]) -> [DecoratedChatItem]
 }
 
-public struct DecoratedChatItem {
+public struct DecoratedChatItem: UniqueIdentificable {
+    public let uid: String
     public let chatItem: ChatItemProtocol
     public let decorationAttributes: ChatItemDecorationAttributesProtocol?
+
     public init(chatItem: ChatItemProtocol, decorationAttributes: ChatItemDecorationAttributesProtocol?) {
+        self.init(uid: chatItem.uid, chatItem: chatItem, decorationAttributes: decorationAttributes)
+    }
+
+    public init(uid: String, chatItem: ChatItemProtocol, decorationAttributes: ChatItemDecorationAttributesProtocol?) {
+        self.uid = uid
         self.chatItem = chatItem
         self.decorationAttributes = decorationAttributes
     }
 }
 
 public struct ChatItemCompanion: UniqueIdentificable {
+    public let uid: String
     public let chatItem: ChatItemProtocol
     public let presenter: ChatItemPresenterProtocol
     public var decorationAttributes: ChatItemDecorationAttributesProtocol?
-    public var uid: String {
-        return self.chatItem.uid
-    }
 }

--- a/Chatto/Source/ChatController/BaseChatViewController+Changes.swift
+++ b/Chatto/Source/ChatController/BaseChatViewController+Changes.swift
@@ -201,7 +201,7 @@ extension BaseChatViewController: ChatDataSourceDelegateProtocol {
 
     private func createModelUpdates(newItems newItems: [ChatItemProtocol], oldItems: ChatItemCompanionCollection, collectionViewWidth: CGFloat) -> (changes: CollectionChanges, updateModelClosure: () -> Void) {
         let newDecoratedItems = self.chatItemsDecorator?.decorateItems(newItems) ?? newItems.map { DecoratedChatItem(chatItem: $0, decorationAttributes: nil) }
-        let changes = Chatto.generateChanges(oldCollection: oldItems.map { $0.chatItem }, newCollection: newDecoratedItems.map { $0.chatItem })
+        let changes = Chatto.generateChanges(oldCollection: oldItems.lazy.map { $0 }, newCollection: newDecoratedItems.lazy.map { $0 })
         let itemCompanionCollection = self.createCompanionCollection(fromChatItems: newDecoratedItems, previousCompanionCollection: oldItems)
         let layoutModel = self.createLayoutModel(itemCompanionCollection, collectionViewWidth: collectionViewWidth)
         let updateModelClosure : () -> Void = { [weak self] in
@@ -220,12 +220,12 @@ extension BaseChatViewController: ChatDataSourceDelegateProtocol {
             // Oherwise updateVisibleCells may try to update existing cell with a new presenter which is working with a different type of cell
 
             // Optimization: reuse presenter if it's the same instance.
-            if let oldChatItemCompanion = oldItems[chatItem.uid] where oldChatItemCompanion.chatItem === chatItem {
+            if let oldChatItemCompanion = oldItems[decoratedChatItem.uid] where oldChatItemCompanion.chatItem === chatItem {
                 presenter = oldChatItemCompanion.presenter
             } else {
                 presenter = self.createPresenterForChatItem(decoratedChatItem.chatItem)
             }
-            return ChatItemCompanion(chatItem: decoratedChatItem.chatItem, presenter: presenter, decorationAttributes: decoratedChatItem.decorationAttributes)
+            return ChatItemCompanion(uid: decoratedChatItem.uid, chatItem: decoratedChatItem.chatItem, presenter: presenter, decorationAttributes: decoratedChatItem.decorationAttributes)
         })
     }
 


### PR DESCRIPTION
Consider:

1. You have a ChatMessage model object wich conforms to ChatItem (it's got a uid property)
2. You send a new message. The uid is some client-side generated id.
3. Message is sent. The uid of the message changes to server-side id

AR: The existing cell will be removed from the collection view and a new one will be inserted.

With this change the ChatItemsDecorator has the opportunity to override the uid used by the changes generator engine. For instance, it could return the client id so the same cell is reused
