### PR TITLE
Adds some configuration to tweak how updates are performed:

### DIFF
--- a/Chatto/Source/ChatController/BaseChatViewController+Presenters.swift
+++ b/Chatto/Source/ChatController/BaseChatViewController+Presenters.swift
@@ -45,6 +45,19 @@ extension BaseChatViewController: ChatCollectionViewLayoutDelegate {
             self.presentersByCell.removeObjectForKey(cell)
             oldPresenterForCell.cellWasHidden(cell)
         }
+
+        if self.updatesConfig.trackVisibleCells {
+            if let visibleCell = self.visibleCells[indexPath] where visibleCell === cell {
+                self.visibleCells[indexPath] = nil
+            } else {
+                self.visibleCells.forEach({ (indexPath, storedCell) in
+                    if cell === storedCell {
+                        // Inconsistency found, likely due to very fast updates
+                        self.visibleCells[indexPath] = nil
+                    }
+                })
+            }
+        }
     }
 
     public func collectionView(collectionView: UICollectionView, willDisplayCell cell: UICollectionViewCell, forItemAtIndexPath indexPath: NSIndexPath) {
@@ -52,6 +65,9 @@ extension BaseChatViewController: ChatCollectionViewLayoutDelegate {
 
         let presenter = self.presenterForIndexPath(indexPath)
         self.presentersByCell.setObject(presenter, forKey: cell)
+        if self.updatesConfig.trackVisibleCells {
+            self.visibleCells[indexPath] = cell
+        }
 
         if self.isAdjustingInputContainer {
             UIView.performWithoutAnimation({

--- a/Chatto/Source/ChatController/BaseChatViewController.swift
+++ b/Chatto/Source/ChatController/BaseChatViewController.swift
@@ -39,6 +39,14 @@ public class BaseChatViewController: UIViewController, UICollectionViewDataSourc
 
     public var constants = Constants()
 
+    public struct UpdatesConfig {
+        public var trackVisibleCells = false // When updating very fast, UICollectionView.cellForItemAtIndexPath is not reliable, may return cell from the previous state (*)
+        public var fastUpdates = false // Allows another performBatchUpdates to be called before completion of a previous one (not recommended). When enabling this it's also recommended to enable `trackVisibleCells` as (*) may happen.
+        public var coalesceUpdates = false // If receiving data source updates too fast, while an update it's being processed, only the last one will be executed
+    }
+
+    public var updatesConfig =  UpdatesConfig()
+
     public private(set) var collectionView: UICollectionView!
     public final internal(set) var chatItemCompanionCollection: ChatItemCompanionCollection = ReadOnlyOrderedDictionary(items: [])
     private var _chatDataSource: ChatDataSourceProtocol?
@@ -236,6 +244,7 @@ public class BaseChatViewController: UIViewController, UICollectionViewDataSourc
     var presenterFactory: ChatItemPresenterFactoryProtocol!
     let presentersByCell = NSMapTable(keyOptions: .WeakMemory, valueOptions: .WeakMemory)
     var updateQueue: SerialTaskQueueProtocol = SerialTaskQueue()
+    var visibleCells: [NSIndexPath: UICollectionViewCell] = [:] // @see UpdatesConfig.trackVisibleCells
 
     /**
      - You can use a decorator to:

--- a/Chatto/Source/ChatController/Collaborators/CollectionChanges.swift
+++ b/Chatto/Source/ChatController/Collaborators/CollectionChanges.swift
@@ -96,3 +96,26 @@ func generateChanges(oldCollection oldCollection: [UniqueIdentificable], newColl
 
     return CollectionChanges(insertedIndexPaths: insertedIndexPaths, deletedIndexPaths: deletedIndexPaths, movedIndexPaths: movedIndexPaths)
 }
+
+func updated<T: Any>(collection collection: [NSIndexPath: T], withChanges changes: CollectionChanges) -> [NSIndexPath: T] {
+    var result = collection
+
+    changes.deletedIndexPaths.forEach { (indexPath) in
+        result[indexPath] = nil
+    }
+
+    var movedDestinations = Set<NSIndexPath>()
+    changes.movedIndexPaths.forEach { (move) in
+        result[move.indexPathNew] = collection[move.indexPathOld]
+        movedDestinations.insert(move.indexPathNew)
+        if !movedDestinations.contains(move.indexPathOld) {
+            result[move.indexPathOld] = nil
+        }
+    }
+
+    changes.insertedIndexPaths.forEach { (indexPath) in
+        result[indexPath] = nil
+    }
+
+    return result
+}

--- a/Chatto/Source/SerialTaskQueue.swift
+++ b/Chatto/Source/SerialTaskQueue.swift
@@ -30,6 +30,7 @@ protocol SerialTaskQueueProtocol {
     func addTask(task: TaskClosure)
     func start()
     func stop()
+    func flushQueue()
     var isEmpty: Bool { get }
 }
 
@@ -50,6 +51,10 @@ final class SerialTaskQueue: SerialTaskQueueProtocol {
 
     func stop() {
         self.isStopped = true
+    }
+
+    func flushQueue() {
+        self.tasksQueue.removeAll()
     }
 
     var isEmpty: Bool {

--- a/Chatto/Tests/ChatController/BaseChatViewControllerTestHelpers.swift
+++ b/Chatto/Tests/ChatController/BaseChatViewControllerTestHelpers.swift
@@ -129,9 +129,9 @@ class FakeChatItem: ChatItemProtocol {
 final class SerialTaskQueueTestHelper: SerialTaskQueueProtocol {
     var onAllTasksFinished: (() -> Void)?
 
-    private var isBusy = false
-    private var isStopped = true
-    private var tasksQueue = [TaskClosure]()
+    var isBusy = false
+    var isStopped = true
+    var tasksQueue = [TaskClosure]()
 
     func addTask(task: TaskClosure) {
         self.tasksQueue.append(task)
@@ -149,6 +149,10 @@ final class SerialTaskQueueTestHelper: SerialTaskQueueProtocol {
 
     var isEmpty: Bool {
         return self.tasksQueue.isEmpty
+    }
+
+    func flushQueue() {
+        self.tasksQueue.removeAll()
     }
 
     private func maybeExecuteNextTask() {

--- a/Chatto/Tests/ChatController/CollectionChangesTests.swift
+++ b/Chatto/Tests/ChatController/CollectionChangesTests.swift
@@ -83,6 +83,44 @@ class CollectionChangesTests: XCTestCase {
         XCTAssertEqual(changes.insertedIndexPaths, [NSIndexPath(forItem: 0, inSection: 0)])
         XCTAssertEqual(Set(changes.movedIndexPaths), [Move(0, to: 2), Move(2, to: 1)])
     }
+
+    func testThatAppliesChangesToCollection() {
+        // (0, 1, 2, 3, 4) -> (2, 3, new, 4)
+
+        let indexPath0 = NSIndexPath(forItem: 0, inSection: 0)
+        let indexPath1 = NSIndexPath(forItem: 1, inSection: 0)
+        let indexPath2 = NSIndexPath(forItem: 2, inSection: 0)
+        let indexPath3 = NSIndexPath(forItem: 3, inSection: 0)
+        let indexPath4 = NSIndexPath(forItem: 4, inSection: 0)
+
+        let collection = [
+            indexPath0: 0,
+            indexPath1: 1,
+            indexPath2: 2,
+            indexPath3: 3,
+            indexPath4: 4,
+        ]
+
+        let deletions = Set([indexPath0, indexPath1])
+        let insertions = Set([indexPath2])
+        let movements = [
+            CollectionChangeMove(indexPathOld: indexPath2, indexPathNew: indexPath0),
+            CollectionChangeMove(indexPathOld: indexPath3, indexPathNew: indexPath1),
+            CollectionChangeMove(indexPathOld: indexPath4, indexPathNew: indexPath3)
+        ]
+
+        let changes = CollectionChanges(insertedIndexPaths: insertions, deletedIndexPaths: deletions, movedIndexPaths:movements)
+        let result = updated(collection: collection, withChanges: changes)
+
+        let expected = [
+            indexPath0: 2,
+            indexPath1: 3,
+            // indexPath2: new
+            indexPath3: 4,
+        ]
+
+        XCTAssertEqual(result, expected)
+    }
 }
 
 func Item(uid: String) -> UniqueIdentificable {


### PR DESCRIPTION
Allows enabling/disabling of:
 - Coalesce updates: when receiving updates from the data source while an update is being performed, only the last one will be actually executed.
 - Fast updates: allows next performBatchUpdate before completion of the previous one
 - Tracks visible views: keeps track of cells on-screen instead of relying on indexPathsForVisibleItems and indexPathForCell, which are unreliable on fast updates.