### PR TITLE
Fixes for fast-queueing

### DIFF
--- a/Chatto/Source/ChatController/BaseChatViewController+Presenters.swift
+++ b/Chatto/Source/ChatController/BaseChatViewController+Presenters.swift
@@ -46,7 +46,7 @@ extension BaseChatViewController: ChatCollectionViewLayoutDelegate {
             oldPresenterForCell.cellWasHidden(cell)
         }
 
-        if self.updatesConfig.trackVisibleCells {
+        if self.updatesConfig.fastUpdates {
             if let visibleCell = self.visibleCells[indexPath] where visibleCell === cell {
                 self.visibleCells[indexPath] = nil
             } else {
@@ -65,7 +65,7 @@ extension BaseChatViewController: ChatCollectionViewLayoutDelegate {
 
         let presenter = self.presenterForIndexPath(indexPath)
         self.presentersByCell.setObject(presenter, forKey: cell)
-        if self.updatesConfig.trackVisibleCells {
+        if self.updatesConfig.fastUpdates {
             self.visibleCells[indexPath] = cell
         }
 


### PR DESCRIPTION
Avoid doing reloadData while there are perfomBatchUpdates animating: https://github.com/diegosanchezr/UICollectionViewStressing/tree/master/GhostCells

Relying on tracked visible cells and transforming then with CollectionChanges is not reliable. It's safe in terms of giving to the presenters a cell of a correct type, but it may end giving a presenter a cell that doesn't belong to it. Instead, now we take the cells from indexPathsForVisibleItems + cellForItemAtIndexPath and use the tracked cells just to detect inconsistencies. If this happens, we delay the update until the animations finish hoping the inconsistency will go away. If the consistency stays after all animations have finished we'll fall back to reloadData.
