### PR TITLE
Fixes text sizing issue

### DIFF
--- a/ChattoAdditions/Source/Chat Items/TextMessages/Views/TextBubbleView.swift
+++ b/ChattoAdditions/Source/Chat Items/TextMessages/Views/TextBubbleView.swift
@@ -137,17 +137,17 @@ public final class TextBubbleView: UIView, MaximumLayoutWidthSpecificable, Backg
         let textInsets = style.textInsets(viewModel: viewModel, isSelected: self.selected)
         let bubbleImage = self.style.bubbleImage(viewModel: self.textMessageViewModel, isSelected: self.selected)
         let borderImage = self.style.bubbleImageBorder(viewModel: self.textMessageViewModel, isSelected: self.selected)
-
-        if self.textView.font != font { self.textView.font = font}
-        if self.textView.text != viewModel.text {self.textView.text = viewModel.text}
-        if self.textView.textContainerInset != textInsets { self.textView.textContainerInset = textInsets }
-        if self.textView.textColor != textColor {
+        let needsToUpdateText = self.textView.text != viewModel.text || self.textView.textColor != textColor || self.textView.font != font
+        if needsToUpdateText {
+            self.textView.font = font
             self.textView.textColor = textColor
             self.textView.linkTextAttributes = [
                 NSForegroundColorAttributeName: textColor,
                 NSUnderlineStyleAttributeName : NSUnderlineStyle.StyleSingle.rawValue
             ]
+            self.textView.text = viewModel.text
         }
+        if self.textView.textContainerInset != textInsets { self.textView.textContainerInset = textInsets }
         if self.bubbleImageView.image != bubbleImage { self.bubbleImageView.image = bubbleImage}
         if self.borderImageView.image != borderImage { self.borderImageView.image = borderImage }
     }


### PR DESCRIPTION
Fixes text sizing issue. Setting UITextView.textColor after UITextView.text may result in a NSTextStorage string that doesn't match our size calculation routine.

See https://github.com/diegosanchezr/UITextView-Sizing/commit/60c85da46bfef03bc8bbd3a8387ff4bee49d38db and https://github.com/diegosanchezr/UITextView-Sizing/commit/ab431ff6609527a12297e9e8477f759cab8fff23

Fixes https://github.com/badoo/Chatto/issues/129