### PR TITLE
Fix photo message cell style Colors initializer

### DIFF
--- a/ChattoAdditions/Source/Chat Items/PhotoMessages/Views/PhotoMessageCollectionViewCellDefaultStyle.swift
+++ b/ChattoAdditions/Source/Chat Items/PhotoMessages/Views/PhotoMessageCollectionViewCellDefaultStyle.swift
@@ -70,6 +70,18 @@ public class PhotoMessageCollectionViewCellDefaultStyle: PhotoMessageCollectionV
         public let progressIndicatorColorIncoming: UIColor
         public let progressIndicatorColorOutgoing: UIColor
         public let overlayColor: UIColor
+        public init(
+            placeholderIconTintIncoming: UIColor,
+            placeholderIconTintOutgoing: UIColor,
+            progressIndicatorColorIncoming: UIColor,
+            progressIndicatorColorOutgoing: UIColor,
+            overlayColor: UIColor) {
+                self.placeholderIconTintIncoming = placeholderIconTintIncoming
+                self.placeholderIconTintOutgoing = placeholderIconTintOutgoing
+                self.progressIndicatorColorIncoming = progressIndicatorColorIncoming
+                self.progressIndicatorColorOutgoing = progressIndicatorColorOutgoing
+                self.overlayColor = overlayColor
+        }
     }
 
     let bubbleMasks: BubbleMasks


### PR DESCRIPTION
Added a public initializer to `Colors` struct of `PhotoMessageCollectionViewCellDefaultStyle` to make it subclassible.
See this: http://stackoverflow.com/a/27635674/3160561