### PR TITLE
Fix constraint incompatibility

### DIFF
--- a/Chatto/Source/ChatController/ChatViewController.swift
+++ b/Chatto/Source/ChatController/ChatViewController.swift
@@ -111,6 +111,7 @@ public class ChatViewController: UIViewController, UICollectionViewDataSource, U
 
     private var inputContainerBottomConstraint: NSLayoutConstraint!
     private var heightConstraint: NSLayoutConstraint!
+    private var topConstraint: NSLayoutConstraint!
     private func addInputViews() {
         self.inputContainer = UIView(frame: CGRect.zero)
         self.inputContainer.autoresizingMask = .None
@@ -126,7 +127,8 @@ public class ChatViewController: UIViewController, UICollectionViewDataSource, U
         let inputView = self.createChatInputView()
         self.inputContainer.addSubview(inputView)
         heightConstraint = NSLayoutConstraint(item: self.inputContainer, attribute: .Height, relatedBy: .Equal, toItem: nil, attribute: .NotAnAttribute, multiplier: 1, constant: 0)
-        self.inputContainer.addConstraint(NSLayoutConstraint(item: self.inputContainer, attribute: .Top, relatedBy: .Equal, toItem: inputView, attribute: .Top, multiplier: 1, constant: 0))
+        topConstraint = NSLayoutConstraint(item: self.inputContainer, attribute: .Top, relatedBy: .Equal, toItem: inputView, attribute: .Top, multiplier: 1, constant: 0)
+        self.inputContainer.addConstraint(topConstraint)
         self.inputContainer.addConstraint(NSLayoutConstraint(item: self.inputContainer, attribute: .Leading, relatedBy: .Equal, toItem: inputView, attribute: .Leading, multiplier: 1, constant: 0))
         self.inputContainer.addConstraint(NSLayoutConstraint(item: self.inputContainer, attribute: .Bottom, relatedBy: .Equal, toItem: inputView, attribute: .Bottom, multiplier: 1, constant: 0))
         self.inputContainer.addConstraint(NSLayoutConstraint(item: self.inputContainer, attribute: .Trailing, relatedBy: .Equal, toItem: inputView, attribute: .Trailing, multiplier: 1, constant: 0))
@@ -156,7 +158,15 @@ public class ChatViewController: UIViewController, UICollectionViewDataSource, U
     }
 
     public func hideInputContainer(hide: Bool) {
-        self.heightConstraint.active = hide
+        if (hide) {
+            self.inputContainer.removeConstraint(topConstraint)
+            self.inputContainer.addConstraint(heightConstraint)
+        }
+        else {
+            self.inputContainer.removeConstraint(heightConstraint)
+            self.inputContainer.addConstraint(topConstraint)
+        }
+
         self.inputContainer.setNeedsUpdateConstraints()
     }
 

--- a/Chatto/Source/ChatController/ChatViewController.swift
+++ b/Chatto/Source/ChatController/ChatViewController.swift
@@ -110,10 +110,12 @@ public class ChatViewController: UIViewController, UICollectionViewDataSource, U
     }
 
     private var inputContainerBottomConstraint: NSLayoutConstraint!
+    private var heightConstraint: NSLayoutConstraint!
     private func addInputViews() {
         self.inputContainer = UIView(frame: CGRect.zero)
         self.inputContainer.autoresizingMask = .None
         self.inputContainer.translatesAutoresizingMaskIntoConstraints = false
+        self.inputContainer.clipsToBounds = true
         self.view.addSubview(self.inputContainer)
         self.view.addConstraint(NSLayoutConstraint(item: self.inputContainer, attribute: .Top, relatedBy: .GreaterThanOrEqual, toItem: self.topLayoutGuide, attribute: .Bottom, multiplier: 1, constant: 0))
         self.view.addConstraint(NSLayoutConstraint(item: self.view, attribute: .Leading, relatedBy: .Equal, toItem: self.inputContainer, attribute: .Leading, multiplier: 1, constant: 0))
@@ -123,10 +125,13 @@ public class ChatViewController: UIViewController, UICollectionViewDataSource, U
 
         let inputView = self.createChatInputView()
         self.inputContainer.addSubview(inputView)
+        heightConstraint = NSLayoutConstraint(item: self.inputContainer, attribute: .Height, relatedBy: .Equal, toItem: nil, attribute: .NotAnAttribute, multiplier: 1, constant: 0)
         self.inputContainer.addConstraint(NSLayoutConstraint(item: self.inputContainer, attribute: .Top, relatedBy: .Equal, toItem: inputView, attribute: .Top, multiplier: 1, constant: 0))
         self.inputContainer.addConstraint(NSLayoutConstraint(item: self.inputContainer, attribute: .Leading, relatedBy: .Equal, toItem: inputView, attribute: .Leading, multiplier: 1, constant: 0))
         self.inputContainer.addConstraint(NSLayoutConstraint(item: self.inputContainer, attribute: .Bottom, relatedBy: .Equal, toItem: inputView, attribute: .Bottom, multiplier: 1, constant: 0))
         self.inputContainer.addConstraint(NSLayoutConstraint(item: self.inputContainer, attribute: .Trailing, relatedBy: .Equal, toItem: inputView, attribute: .Trailing, multiplier: 1, constant: 0))
+
+        hideInputContainer(false)
 
         self.keyboardTracker = KeyboardTracker(viewController: self, inputContainer: self.inputContainer, inputContainerBottomContraint: self.inputContainerBottomConstraint, notificationCenter: self.notificationCenter)
     }
@@ -148,6 +153,11 @@ public class ChatViewController: UIViewController, UICollectionViewDataSource, U
             self.updateQueue.start()
             self.isFirstLayout = false
         }
+    }
+
+    public func hideInputContainer(hide: Bool) {
+        self.heightConstraint.active = hide
+        self.inputContainer.setNeedsUpdateConstraints()
     }
 
     private func adjustCollectionViewInsets() {

--- a/ChattoAdditions/Source/Input/ChatInputBarPresenter.swift
+++ b/ChattoAdditions/Source/Input/ChatInputBarPresenter.swift
@@ -25,7 +25,7 @@
 import UIKit
 
 @objc public class ChatInputBarPresenter: NSObject {
-    let chatInputView: ChatInputBar
+    public let chatInputView: ChatInputBar
     let chatInputItems: [ChatInputItemProtocol]
 
     public init(chatInputView: ChatInputBar, chatInputItems: [ChatInputItemProtocol]) {
@@ -92,7 +92,7 @@ extension ChatInputBarPresenter: ChatInputBarDelegate {
         }
     }
 
-    func inputBar(inputBar: ChatInputBar, didReceiveFocusOnItem item: ChatInputItemProtocol) {
+    public func inputBar(inputBar: ChatInputBar, didReceiveFocusOnItem item: ChatInputItemProtocol) {
         guard item.presentationMode != .None else { return }
         guard item !== self.focusedItem else { return }
 


### PR DESCRIPTION
SUMMARY:
The previous submit caused constraint inconsistencies. The height constraint conflicted with the existing top constraint. Fix was to add and remove the height and top constraints instead of activating and deactivating them.

TEST:
Build and note in the console (Xcode or OS X) and see that not runtime constraint conflicts are reported when the button bar appears in the Bot UI.