### PR TITLE
Fixes issue with hidesBottomBarWhenPushed and a tabbar

### DIFF
--- a/Chatto/Source/ChatController/BaseChatViewController.swift
+++ b/Chatto/Source/ChatController/BaseChatViewController.swift
@@ -183,7 +183,13 @@ public class BaseChatViewController: UIViewController, UICollectionViewDataSourc
         if self.isFirstLayout {
             self.updateQueue.start()
             self.isFirstLayout = false
-            self.inputContainerBottomConstraint.constant = self.bottomLayoutGuide.length
+            // If we have been pushed on nav controller and hidesBottomBarWhenPushed = true, then ignore bottomLayoutMargin
+            // because it has incorrect value when we actually have a bottom bar (tabbar)
+            if hidesBottomBarWhenPushed && navigationController?.viewControllers.count > 1 && navigationController?.viewControllers.last == self {
+                self.inputContainerBottomConstraint.constant = 0
+            } else {
+                self.inputContainerBottomConstraint.constant = self.bottomLayoutGuide.length
+            }
         }
     }
 


### PR DESCRIPTION
Fixes the issue #197 

The solution that I propose has a check on whether view controller has been pushed like this:
`navigationController?.viewControllers.count > 1 && navigationController?.viewControllers.last == self
`

Note that it is not fully accurate, since we may have a situation where we have a nav controller with preset view controllers (our chat view controller being the last one) and we present that nav controller with `presentViewController(_:animated:completion)`. Then the check would still succeed although the view controller wouldn't be pushed. **However** AFAIK it's not an issue because in a case like that the bottom bar is still hidden and so bottomLayoutGuide.length is 0.