### PR TITLE
fixed heightForCell being called twice

### DIFF
--- a/ChattoApp/ChattoApp/Source/DemoChatViewController.swift
+++ b/ChattoApp/ChattoApp/Source/DemoChatViewController.swift
@@ -32,7 +32,6 @@ class DemoChatViewController: BaseChatViewController {
     var dataSource: FakeDataSource! {
         didSet {
             self.chatDataSource = self.dataSource
-            self.chatDataSourceDidUpdate(self.dataSource)
         }
     }
 


### PR DESCRIPTION
call chatDataSourceDidUpdate, will call [`enqueueModelUpdate(updateType updateType: UpdateType)`](https://github.com/badoo/Chatto/blob/cbb32790a7f5b25fa098511b978d4418720eec32/Chatto/Source/ChatController/BaseChatViewController%2BChanges.swift#L37)

assign dataSource to DemoChatViewController, will call [`enqueueModelUpdate(updateType updateType: UpdateType)`](https://github.com/badoo/Chatto/blob/cbb32790a7f5b25fa098511b978d4418720eec32/Chatto/Source/ChatController/BaseChatViewController.swift#L66)

call `enqueueModelUpdate` will call heightForCell