### PR TITLE
ignore `bottomLayoutGuide` when `hidesBottomBarWhenPushed == true`

### DIFF
--- a/Chatto/Source/ChatController/BaseChatViewController.swift
+++ b/Chatto/Source/ChatController/BaseChatViewController.swift
@@ -162,7 +162,8 @@ open class BaseChatViewController: UIViewController, UICollectionViewDataSource,
         let layoutBlock = { [weak self] (bottomMargin: CGFloat) in
             guard let sSelf = self else { return }
             sSelf.isAdjustingInputContainer = true
-            sSelf.inputContainerBottomConstraint.constant = max(bottomMargin, sSelf.bottomLayoutGuide.length)
+            let bottomConstraint = sSelf.hidesBottomBarWhenPushed ? 0 : sSelf.bottomLayoutGuide.length
+            sSelf.inputContainerBottomConstraint.constant = max(bottomMargin, bottomConstraint)
             sSelf.view.layoutIfNeeded()
             sSelf.isAdjustingInputContainer = false
         }


### PR DESCRIPTION
... otherwise I found that even when pushing from a navigation controller embedded in a UITabbarViewController with `hidesBottomBarWhenPushed == true`, `bottomLayGuide.length` would be set to 49. Elsewhere in the code `hidesBottomBarWhenPushed` is used to ignore `bottomLayGuide.length`, see: `viewDidLayoutSubviews()`