### PR TITLE
improve: avoid ambiguous use of init()

### DIFF
--- a/ChattoAdditions/Source/Chat Items/BaseMessage/Views/BaseMessageCollectionViewCellDefaultStyle.swift
+++ b/ChattoAdditions/Source/Chat Items/BaseMessage/Views/BaseMessageCollectionViewCellDefaultStyle.swift
@@ -108,7 +108,7 @@ open class BaseMessageCollectionViewCellDefaultStyle: BaseMessageCollectionViewC
             self.avatarStyle = avatarStyle
     }
     
-    convenience init() {
+    public convenience init() {
         self.init(
             colors: Class.createDefaultColors(),
             bubbleBorderImages: Class.createDefaultBubbleBorderImages(),

--- a/ChattoAdditions/Source/Chat Items/BaseMessage/Views/BaseMessageCollectionViewCellDefaultStyle.swift
+++ b/ChattoAdditions/Source/Chat Items/BaseMessage/Views/BaseMessageCollectionViewCellDefaultStyle.swift
@@ -94,18 +94,28 @@ open class BaseMessageCollectionViewCellDefaultStyle: BaseMessageCollectionViewC
     let dateTextStyle: DateTextStyle
     let avatarStyle: AvatarStyle
     public init (
-        colors: Colors = Class.createDefaultColors(),
-        bubbleBorderImages: BubbleBorderImages? = Class.createDefaultBubbleBorderImages(),
-        failedIconImages: FailedIconImages = Class.createDefaultFailedIconImages(),
-        layoutConstants: BaseMessageCollectionViewCellLayoutConstants = Class.createDefaultLayoutConstants(),
-        dateTextStyle: DateTextStyle = Class.createDefaultDateTextStyle(),
-        avatarStyle: AvatarStyle = AvatarStyle()) {
+        colors: Colors,
+        bubbleBorderImages: BubbleBorderImages,
+        failedIconImages: FailedIconImages,
+        layoutConstants: BaseMessageCollectionViewCellLayoutConstants,
+        dateTextStyle: DateTextStyle,
+        avatarStyle: AvatarStyle) {
             self.colors = colors
             self.bubbleBorderImages = bubbleBorderImages
             self.failedIconImages = failedIconImages
             self.layoutConstants = layoutConstants
             self.dateTextStyle = dateTextStyle
             self.avatarStyle = avatarStyle
+    }
+    
+    convenience init() {
+        self.init(
+            colors: Class.createDefaultColors(),
+            bubbleBorderImages: Class.createDefaultBubbleBorderImages(),
+            failedIconImages: Class.createDefaultFailedIconImages(),
+            layoutConstants: Class.createDefaultLayoutConstants(),
+            dateTextStyle: Class.createDefaultDateTextStyle(),
+            avatarStyle: AvatarStyle())
     }
 
     public lazy var baseColorIncoming: UIColor = self.colors.incoming()


### PR DESCRIPTION
avoid ambiguous use of init() when to create subclass inherits from BaseMessageCollectionViewCellDefaultStyle

now we can create subclass more easily. like this
```swift
class DemoMessageCollectionViewCellStyle: BaseMessageCollectionViewCellDefaultStyle {
    typealias Class = DemoMessageCollectionViewCellStyle
    
    convenience init() {
        self.init(
            colors: Class.createColors(),
            bubbleBorderImages: Class.createDefaultBubbleBorderImages(),
            failedIconImages: Class.createDefaultFailedIconImages(),
            layoutConstants: Class.createDefaultLayoutConstants(),
            dateTextStyle: Class.createDefaultDateTextStyle(),
            avatarStyle: AvatarStyle()
        )
    }

    static func createColors() -> Colors {
        return Colors(incoming: UIColor.bma_color(rgb: 0xE6ECF2), outgoing: UIColor.greenColor())
    }
}
```