### PR TITLE
Add new decoration property to enable/disable failed icon for a messa…

### DIFF
--- a/ChattoAdditions/Source/Chat Items/BaseMessage/BaseMessagePresenter.swift
+++ b/ChattoAdditions/Source/Chat Items/BaseMessage/BaseMessagePresenter.swift
@@ -96,8 +96,9 @@ open class BaseMessagePresenter<BubbleViewT, ViewModelBuilderT, InteractionHandl
     public var decorationAttributes: ChatItemDecorationAttributes!
     open func configureCell(_ cell: CellT, decorationAttributes: ChatItemDecorationAttributes, animated: Bool, additionalConfiguration: (() -> Void)?) {
         cell.performBatchUpdates({ () -> Void in
-            self.messageViewModel.showsTail = decorationAttributes.showsTail
-            self.messageViewModel.showsAvatar = decorationAttributes.showsAvatar
+            self.messageViewModel.showsTail = decorationAttributes.canShowTail
+            self.messageViewModel.showsAvatar = decorationAttributes.canShowAvatar
+            self.messageViewModel.canShowFailedIcon = decorationAttributes.canShowFailedIcon
             // just in case something went wrong while showing UIMenuController
             self.messageViewModel.isUserInteractionEnabled = true
             cell.baseStyle = self.cellStyle

--- a/ChattoAdditions/Source/Chat Items/BaseMessage/BaseMessageViewModel.swift
+++ b/ChattoAdditions/Source/Chat Items/BaseMessage/BaseMessageViewModel.swift
@@ -48,6 +48,7 @@ public protocol MessageViewModelProtocol: class { // why class? https://gist.git
     var isUserInteractionEnabled: Bool { get set }
     var showsTail: Bool { get set }
     var showsFailedIcon: Bool { get }
+    var canShowFailedIcon: Bool { get set }
     var showsAvatar: Bool { get set }
     var date: String { get }
     var status: MessageViewModelStatus { get }
@@ -109,6 +110,15 @@ extension DecoratedMessageViewModelProtocol {
         return self.messageViewModel.showsFailedIcon
     }
 
+    public var canShowFailedIcon: Bool {
+        get {
+            return self.messageViewModel.canShowFailedIcon
+        }
+        set {
+            self.messageViewModel.canShowFailedIcon = newValue
+        }
+    }
+
     public var avatarImage: Observable<UIImage?> {
         get {
             return self.messageViewModel.avatarImage
@@ -155,6 +165,7 @@ open class MessageViewModel: MessageViewModelProtocol {
     open var showsFailedIcon: Bool {
         return self.status == .failed
     }
+    open var canShowFailedIcon: Bool = true
 
     public var avatarImage: Observable<UIImage?>
 }

--- a/ChattoAdditions/Source/Chat Items/BaseMessage/Views/BaseMessageCollectionViewCell.swift
+++ b/ChattoAdditions/Source/Chat Items/BaseMessage/Views/BaseMessageCollectionViewCell.swift
@@ -105,6 +105,9 @@ open class BaseMessageCollectionViewCell<BubbleViewType>: UICollectionViewCell, 
             self.updateViews()
         }
     }
+    private var shouldShowFailedIcon: Bool {
+        return self.messageViewModel?.canShowFailedIcon == true && self.messageViewModel?.showsFailedIcon == true
+    }
 
     override open var isSelected: Bool {
         didSet {
@@ -197,7 +200,7 @@ open class BaseMessageCollectionViewCell<BubbleViewType>: UICollectionViewCell, 
         if self.isUpdating { return }
         guard let viewModel = self.messageViewModel, let style = self.baseStyle else { return }
         self.bubbleView.isUserInteractionEnabled = viewModel.isUserInteractionEnabled
-        if viewModel.showsFailedIcon {
+        if self.shouldShowFailedIcon {
             self.failedButton.setImage(self.failedIcon, for: .normal)
             self.failedButton.setImage(self.failedIconHighlighted, for: .highlighted)
             self.failedButton.alpha = 1
@@ -262,7 +265,7 @@ open class BaseMessageCollectionViewCell<BubbleViewType>: UICollectionViewCell, 
             maxContainerWidthPercentageForBubbleView: layoutConstants.maxContainerWidthPercentageForBubbleView,
             bubbleView: self.bubbleView,
             isIncoming: self.messageViewModel.isIncoming,
-            isFailed: self.messageViewModel.showsFailedIcon,
+            isFailed: self.shouldShowFailedIcon,
             avatarSize: baseStyle.avatarSize(viewModel: messageViewModel),
             avatarVerticalAlignment: baseStyle.avatarVerticalAlignment(viewModel: messageViewModel)
         )

--- a/ChattoAdditions/Source/Chat Items/ChatItemDecorationAttributes.swift
+++ b/ChattoAdditions/Source/Chat Items/ChatItemDecorationAttributes.swift
@@ -27,11 +27,17 @@ import Chatto
 
 public struct ChatItemDecorationAttributes: ChatItemDecorationAttributesProtocol {
     public let bottomMargin: CGFloat
-    public let showsTail: Bool
-    public let showsAvatar: Bool
-    public init(bottomMargin: CGFloat, showsTail: Bool, showsAvatar: Bool) {
+    public let canShowTail: Bool
+    public let canShowAvatar: Bool
+    public var canShowFailedIcon: Bool
+
+    public init(bottomMargin: CGFloat,
+                canShowTail: Bool,
+                canShowAvatar: Bool,
+                canShowFailedIcon: Bool) {
         self.bottomMargin = bottomMargin
-        self.showsTail = showsTail
-        self.showsAvatar = showsAvatar
+        self.canShowTail = canShowTail
+        self.canShowAvatar = canShowAvatar
+        self.canShowFailedIcon = canShowFailedIcon
     }
 }

--- a/ChattoAdditions/Tests/Chat Items/BaseMessage/BaseMessagePresenterTests.swift
+++ b/ChattoAdditions/Tests/Chat Items/BaseMessage/BaseMessagePresenterTests.swift
@@ -30,7 +30,7 @@ class BaseMessagePresenterTests: XCTestCase {
 
     // BaseMessagePresenter is generic, let's use the photo one for instance
     var presenter: PhotoMessagePresenter<PhotoMessageViewModelDefaultBuilder<PhotoMessageModel<MessageModel>>, PhotoMessageTestHandler>!
-    let decorationAttributes = ChatItemDecorationAttributes(bottomMargin: 0, showsTail: false, showsAvatar: false)
+    let decorationAttributes = ChatItemDecorationAttributes(bottomMargin: 0, canShowTail: false, canShowAvatar: false, canShowFailedIcon: true)
     var interactionHandler: PhotoMessageTestHandler!
     override func setUp() {
         super.setUp()
@@ -70,5 +70,13 @@ class BaseMessagePresenterTests: XCTestCase {
         self.presenter.configureCell(cell, decorationAttributes: self.decorationAttributes)
         cell.onBubbleLongPressEnded?(cell)
         XCTAssertTrue(self.interactionHandler.didHandleEndLongPressOnBubble)
+    }
+
+    func testThat_WhenProvideDecorationAttributes_ThenViewModelIsUpdated() {
+        let cell = PhotoMessageCollectionViewCell(frame: CGRect.zero)
+        var decorationAttributes = self.decorationAttributes
+        decorationAttributes.canShowFailedIcon = false
+        self.presenter.configureCell(cell, decorationAttributes: decorationAttributes)
+        XCTAssertFalse(self.presenter.messageViewModel.canShowFailedIcon)
     }
 }

--- a/ChattoAdditions/Tests/Chat Items/PhotoMessages/PhotoMessagePresenterTests.swift
+++ b/ChattoAdditions/Tests/Chat Items/PhotoMessages/PhotoMessagePresenterTests.swift
@@ -28,7 +28,7 @@ import XCTest
 class PhotoMessagePresenterTests: XCTestCase, UICollectionViewDataSource {
 
     var presenter: PhotoMessagePresenter<PhotoMessageViewModelDefaultBuilder<PhotoMessageModel<MessageModel>>, PhotoMessageTestHandler>!
-    let decorationAttributes = ChatItemDecorationAttributes(bottomMargin: 0, showsTail: false, showsAvatar: false)
+    let decorationAttributes = ChatItemDecorationAttributes(bottomMargin: 0, canShowTail: false, canShowAvatar: false, canShowFailedIcon: true)
     let testImage = UIImage()
     override func setUp() {
         super.setUp()

--- a/ChattoAdditions/Tests/Chat Items/TextMessages/TextMessagePresenterTests.swift
+++ b/ChattoAdditions/Tests/Chat Items/TextMessages/TextMessagePresenterTests.swift
@@ -29,7 +29,7 @@ import Chatto
 class TextMessagePresenterTests: XCTestCase, UICollectionViewDataSource {
 
     var presenter: TextMessagePresenter<TextMessageViewModelDefaultBuilder<TextMessageModel<MessageModel>>, TextMessageTestHandler>!
-    let decorationAttributes = ChatItemDecorationAttributes(bottomMargin: 0, showsTail: false, showsAvatar: false)
+    let decorationAttributes = ChatItemDecorationAttributes(bottomMargin: 0, canShowTail: false, canShowAvatar: false, canShowFailedIcon: true)
     override func setUp() {
         super.setUp()
         let viewModelBuilder = TextMessageViewModelDefaultBuilder<TextMessageModel<MessageModel>>()

--- a/ChattoApp/ChattoApp/Source/ChatItemsDemoDecorator.swift
+++ b/ChattoApp/ChattoApp/Source/ChatItemsDemoDecorator.swift
@@ -76,11 +76,10 @@ final class ChatItemsDemoDecorator: ChatItemsDecoratorProtocol {
             decoratedChatItems.append(
                 DecoratedChatItem(
                     chatItem: chatItem,
-                    decorationAttributes: ChatItemDecorationAttributes(
-                        bottomMargin: bottomMargin,
-                        showsTail: showsTail,
-                        showsAvatar: showsTail
-                    )
+                    decorationAttributes: ChatItemDecorationAttributes(bottomMargin: bottomMargin,
+                                                                       canShowTail: showsTail,
+                                                                       canShowAvatar: showsTail,
+                                                                       canShowFailedIcon: true)
                 )
             )
             decoratedChatItems.append(contentsOf: additionalItems)


### PR DESCRIPTION
Add new decoration property to enable/disable failed icon for a message. Change names for the ChatItemDecorationAttributes properties according to the single name convention. Add tests to cover new functionality.

Changes breaks existing interfaces for ChatItemDecorationAttributes and amend MessageViewModelProtocol with new writable property.

