### PR TITLE
Consider safe area inset when ignoring bottomLayoutMargin

### DIFF
--- a/Chatto/Source/ChatController/BaseChatViewController.swift
+++ b/Chatto/Source/ChatController/BaseChatViewController.swift
@@ -177,7 +177,11 @@ open class BaseChatViewController: UIViewController, UICollectionViewDataSource,
         }
 
         if navigatedController.hidesBottomBarWhenPushed && (navigationController?.viewControllers.count ?? 0) > 1 && navigationController?.viewControllers.last == navigatedController {
-            self.inputContainerBottomConstraint.constant = 0
+            if #available(iOS 11, *) {
+                self.inputContainerBottomConstraint.constant = self.view.safeAreaInsets.bottom
+            } else {
+                self.inputContainerBottomConstraint.constant = 0
+            }
         } else {
             self.inputContainerBottomConstraint.constant = self.bottomLayoutGuide.length
         }


### PR DESCRIPTION
<img width="545" alt="2017-11-07 11 08 33" src="https://user-images.githubusercontent.com/3102934/32473671-24293722-c3ac-11e7-82d4-0e53aca6e608.png">
If there is a tab bar and hidesBottomBarWhenPushed = true, the above problem occurs because the safe area insets are not considered.

