### PR TITLE
Allow override of text message `text`

### DIFF
--- a/ChattoAdditions/Source/Chat Items/TextMessages/TextMessageViewModel.swift
+++ b/ChattoAdditions/Source/Chat Items/TextMessages/TextMessageViewModel.swift
@@ -29,7 +29,7 @@ public protocol TextMessageViewModelProtocol: DecoratedMessageViewModelProtocol 
 }
 
 open class TextMessageViewModel<TextMessageModelT: TextMessageModelProtocol>: TextMessageViewModelProtocol {
-    public var text: String {
+    open var text: String {
         return self.textMessage.text
     }
     public let textMessage: TextMessageModelT


### PR DESCRIPTION
This PR enables a client to override the `text` property of TexMessageViewModel in order to display different text depending on message properties.