### PR TITLE
Change camera cell UI after setting new appearance.

### DIFF
--- a/ChattoAdditions/Source/Input/Photos/LiveCameraCell.swift
+++ b/ChattoAdditions/Source/Input/Photos/LiveCameraCell.swift
@@ -54,7 +54,7 @@ class LiveCameraCell: UICollectionViewCell {
 
     var appearance: LiveCameraCellAppearance = LiveCameraCellAppearance.createDefaultAppearance() {
         didSet {
-            self.contentView.backgroundColor = self.appearance.backgroundColor
+            self.updateAppearance()
         }
     }
 
@@ -112,6 +112,11 @@ class LiveCameraCell: UICollectionViewCell {
         self.iconImageView = UIImageView()
         self.iconImageView.contentMode = .center
         self.contentView.addSubview(self.iconImageView)
+    }
+    
+    private func updateAppearance() {
+        self.contentView.backgroundColor = self.appearance.backgroundColor
+        self.updateIcon()
     }
 
     private func updateIcon() {


### PR DESCRIPTION
LiveCameraCell is always using camera icon from default LiveCameraCellAppearance instance during the first appearance on the screen and change it only after this cell was reused. The fix is to update UI after new appearance was set.