### PR TITLE
Relax let to var for text property in TextMessageModel

### DIFF
--- a/ChattoAdditions/Source/Chat Items/TextMessages/TextMessageModel.swift
+++ b/ChattoAdditions/Source/Chat Items/TextMessages/TextMessageModel.swift
@@ -33,7 +33,7 @@ open class TextMessageModel<MessageModelT: MessageModelProtocol>: TextMessageMod
         return self._messageModel
     }
     public let _messageModel: MessageModelT // Can't make messasgeModel: MessageModelT: https://gist.github.com/diegosanchezr/5a66c7af862e1117b556
-    public let text: String
+    open var text: String
     public init(messageModel: MessageModelT, text: String) {
         self._messageModel = messageModel
         self.text = text


### PR DESCRIPTION
This change make it possible to edit the `text` property without having to create a new `TextMessageModel`. I think it makes sense since all properties in `MessageModel` (`uid`, `senderId`, etc.) are already `open var` type.