### PR TITLE
Fix force unwrap in BaseCollectionViewController

### DIFF
--- a/Chatto/Source/ChatController/BaseChatViewController+Changes.swift
+++ b/Chatto/Source/ChatController/BaseChatViewController+Changes.swift
@@ -71,13 +71,14 @@ extension BaseChatViewController {
             return 0
         }
 
-        let contentHeight = self.collectionView.contentSize.height
+        let contentHeight = self.collectionView?.contentSize.height ?? 0
         guard contentHeight > 0 else {
             return 0.5
         }
 
         // Rough estimation
-        let midContentOffset = self.collectionView.contentOffset.y + self.visibleRect().height / 2
+        let collectionViewContentYOffset = self.collectionView?.contentOffset.y ?? 0
+        let midContentOffset = collectionViewContentYOffset + self.visibleRect().height / 2
         return min(max(0, Double(midContentOffset / contentHeight)), 1.0)
     }
 
@@ -98,8 +99,8 @@ extension BaseChatViewController {
 
     private func visibleCellsFromCollectionViewApi() -> [IndexPath: UICollectionViewCell] {
         var visibleCells: [IndexPath: UICollectionViewCell] = [:]
-        self.collectionView.indexPathsForVisibleItems.forEach({ (indexPath) in
-            if let cell = self.collectionView.cellForItem(at: indexPath) {
+        self.collectionView?.indexPathsForVisibleItems.forEach({ (indexPath) in
+            if let cell = self.collectionView?.cellForItem(at: indexPath) {
                 visibleCells[indexPath] = cell
             }
         })
@@ -180,14 +181,14 @@ extension BaseChatViewController {
         if usesBatchUpdates {
             UIView.animate(withDuration: self.constants.updatesAnimationDuration, animations: { () -> Void in
                 self.unfinishedBatchUpdatesCount += 1
-                self.collectionView.performBatchUpdates({ () -> Void in
+                self.collectionView?.performBatchUpdates({ () -> Void in
                     updateModelClosure()
                     self.updateVisibleCells(changes) // For instance, to support removal of tails
 
-                    self.collectionView.deleteItems(at: Array(changes.deletedIndexPaths))
-                    self.collectionView.insertItems(at: Array(changes.insertedIndexPaths))
+                    self.collectionView?.deleteItems(at: Array(changes.deletedIndexPaths))
+                    self.collectionView?.insertItems(at: Array(changes.insertedIndexPaths))
                     for move in changes.movedIndexPaths {
-                        self.collectionView.moveItem(at: move.indexPathOld, to: move.indexPathNew)
+                        self.collectionView?.moveItem(at: move.indexPathOld, to: move.indexPathNew)
                     }
                 }, completion: { [weak self] (_) -> Void in
                     defer { myCompletion() }
@@ -204,8 +205,8 @@ extension BaseChatViewController {
         } else {
             self.visibleCells = [:]
             updateModelClosure()
-            self.collectionView.reloadData()
-            self.collectionView.collectionViewLayout.prepare()
+            self.collectionView?.reloadData()
+            self.collectionView?.collectionViewLayout.prepare()
             if self.placeMessagesFromBottom {
                 self.adjustCollectionViewInsets(shouldUpdateContentOffset: false)
             }
@@ -225,7 +226,7 @@ extension BaseChatViewController {
     }
 
     private func updateModels(newItems: [ChatItemProtocol], oldItems: ChatItemCompanionCollection, updateType: UpdateType, completion: @escaping () -> Void) {
-        let collectionViewWidth = self.collectionView.bounds.width
+        let collectionViewWidth = self.collectionView?.bounds.width ?? 0
         let updateType = self.isFirstLayout ? .firstLoad : updateType
         let performInBackground = updateType != .firstLoad
 
@@ -329,8 +330,9 @@ extension BaseChatViewController {
     }
 
     public func chatCollectionViewLayoutModel() -> ChatCollectionViewLayoutModel {
-        if self.layoutModel.calculatedForWidth != self.collectionView.bounds.width {
-            self.layoutModel = self.createLayoutModel(self.chatItemCompanionCollection, collectionViewWidth: self.collectionView.bounds.width)
+        if let collectionViewWidth = self.collectionView?.bounds.width,
+            self.layoutModel.calculatedForWidth != collectionViewWidth {
+            self.layoutModel = self.createLayoutModel(self.chatItemCompanionCollection, collectionViewWidth: collectionViewWidth)
         }
         return self.layoutModel
     }

--- a/Chatto/Source/ChatController/BaseChatViewController+Changes.swift
+++ b/Chatto/Source/ChatController/BaseChatViewController+Changes.swift
@@ -24,7 +24,7 @@
 
 import Foundation
 
-extension BaseChatViewController {    
+extension BaseChatViewController {
 
     public func enqueueModelUpdate(updateType: UpdateType) {
         let newItems = self.chatDataSource?.chatItems ?? []
@@ -65,19 +65,20 @@ extension BaseChatViewController {
 
     // Returns scrolling position in interval [0, 1], 0 top, 1 bottom
     public var focusPosition: Double {
+        guard let collectionView = self.collectionView else { return 0 }
         if self.isCloseToBottom() {
             return 1
         } else if self.isCloseToTop() {
             return 0
         }
 
-        let contentHeight = self.collectionView?.contentSize.height ?? 0
+        let contentHeight = collectionView.contentSize.height
         guard contentHeight > 0 else {
             return 0.5
         }
 
         // Rough estimation
-        let collectionViewContentYOffset = self.collectionView?.contentOffset.y ?? 0
+        let collectionViewContentYOffset = collectionView.contentOffset.y
         let midContentOffset = collectionViewContentYOffset + self.visibleRect().height / 2
         return min(max(0, Double(midContentOffset / contentHeight)), 1.0)
     }
@@ -99,8 +100,9 @@ extension BaseChatViewController {
 
     private func visibleCellsFromCollectionViewApi() -> [IndexPath: UICollectionViewCell] {
         var visibleCells: [IndexPath: UICollectionViewCell] = [:]
-        self.collectionView?.indexPathsForVisibleItems.forEach({ (indexPath) in
-            if let cell = self.collectionView?.cellForItem(at: indexPath) {
+        guard let collectionView = self.collectionView else { return visibleCells }
+        collectionView.indexPathsForVisibleItems.forEach({ (indexPath) in
+            if let cell = collectionView.cellForItem(at: indexPath) {
                 visibleCells[indexPath] = cell
             }
         })
@@ -128,7 +130,10 @@ extension BaseChatViewController {
                              changes: CollectionChanges,
                              updateType: UpdateType,
                              completion: @escaping () -> Void) {
-
+        guard let collectionView = self.collectionView else {
+            completion()
+            return
+        }
         let usesBatchUpdates: Bool
         do { // Recover from too fast updates...
             let visibleCellsAreValid = self.visibleCellsAreValid(changes: changes)
@@ -181,14 +186,14 @@ extension BaseChatViewController {
         if usesBatchUpdates {
             UIView.animate(withDuration: self.constants.updatesAnimationDuration, animations: { () -> Void in
                 self.unfinishedBatchUpdatesCount += 1
-                self.collectionView?.performBatchUpdates({ () -> Void in
+                collectionView.performBatchUpdates({ () -> Void in
                     updateModelClosure()
                     self.updateVisibleCells(changes) // For instance, to support removal of tails
 
-                    self.collectionView?.deleteItems(at: Array(changes.deletedIndexPaths))
-                    self.collectionView?.insertItems(at: Array(changes.insertedIndexPaths))
+                    collectionView.deleteItems(at: Array(changes.deletedIndexPaths))
+                    collectionView.insertItems(at: Array(changes.insertedIndexPaths))
                     for move in changes.movedIndexPaths {
-                        self.collectionView?.moveItem(at: move.indexPathOld, to: move.indexPathNew)
+                        collectionView.moveItem(at: move.indexPathOld, to: move.indexPathNew)
                     }
                 }, completion: { [weak self] (_) -> Void in
                     defer { myCompletion() }
@@ -205,8 +210,8 @@ extension BaseChatViewController {
         } else {
             self.visibleCells = [:]
             updateModelClosure()
-            self.collectionView?.reloadData()
-            self.collectionView?.collectionViewLayout.prepare()
+            collectionView.reloadData()
+            collectionView.collectionViewLayout.prepare()
             if self.placeMessagesFromBottom {
                 self.adjustCollectionViewInsets(shouldUpdateContentOffset: false)
             }
@@ -226,7 +231,11 @@ extension BaseChatViewController {
     }
 
     private func updateModels(newItems: [ChatItemProtocol], oldItems: ChatItemCompanionCollection, updateType: UpdateType, completion: @escaping () -> Void) {
-        let collectionViewWidth = self.collectionView?.bounds.width ?? 0
+        guard let collectionView = self.collectionView else {
+            completion()
+            return
+        }
+        let collectionViewWidth = collectionView.bounds.width
         let updateType = self.isFirstLayout ? .firstLoad : updateType
         let performInBackground = updateType != .firstLoad
 
@@ -330,9 +339,9 @@ extension BaseChatViewController {
     }
 
     public func chatCollectionViewLayoutModel() -> ChatCollectionViewLayoutModel {
-        if let collectionViewWidth = self.collectionView?.bounds.width,
-            self.layoutModel.calculatedForWidth != collectionViewWidth {
-            self.layoutModel = self.createLayoutModel(self.chatItemCompanionCollection, collectionViewWidth: collectionViewWidth)
+        guard let collectionView = self.collectionView else { return self.layoutModel }
+        if self.layoutModel.calculatedForWidth != collectionView.bounds.width {
+            self.layoutModel = self.createLayoutModel(self.chatItemCompanionCollection, collectionViewWidth: collectionView.bounds.width)
         }
         return self.layoutModel
     }

--- a/Chatto/Source/ChatController/BaseChatViewController+Presenters.swift
+++ b/Chatto/Source/ChatController/BaseChatViewController+Presenters.swift
@@ -123,8 +123,12 @@ extension BaseChatViewController: ChatCollectionViewLayoutDelegate {
 
     public func confugureCollectionViewWithPresenters() {
         assert(self.presenterFactory == nil, "Presenter factory is already initialized")
+        guard let collectionView = self.collectionView else {
+            assertionFailure("CollectionView is not initialized")
+            return
+        }
         self.presenterFactory = self.createPresenterFactory()
-        self.presenterFactory.configure(withCollectionView: self.collectionView)
+        self.presenterFactory.configure(withCollectionView: collectionView )
     }
 
     public func decorationAttributesForIndexPath(_ indexPath: IndexPath) -> ChatItemDecorationAttributesProtocol? {

--- a/Chatto/Source/ChatController/BaseChatViewController+Scrolling.swift
+++ b/Chatto/Source/ChatController/BaseChatViewController+Scrolling.swift
@@ -36,31 +36,48 @@ extension CGFloat {
 extension BaseChatViewController {
 
     public func isScrolledAtBottom() -> Bool {
-        guard self.collectionView.numberOfSections > 0 && self.collectionView.numberOfItems(inSection: 0) > 0 else { return true }
-        let sectionIndex = self.collectionView.numberOfSections - 1
-        let itemIndex = self.collectionView.numberOfItems(inSection: sectionIndex) - 1
+        guard
+            let collectionView = self.collectionView,
+            collectionView.numberOfSections > 0
+                && collectionView.numberOfItems(inSection: 0) > 0
+        else { return true }
+        let sectionIndex = collectionView.numberOfSections - 1
+        let itemIndex = collectionView.numberOfItems(inSection: sectionIndex) - 1
         let lastIndexPath = IndexPath(item: itemIndex, section: sectionIndex)
         return self.isIndexPathVisible(lastIndexPath, atEdge: .bottom)
     }
 
     public func isScrolledAtTop() -> Bool {
-        guard self.collectionView.numberOfSections > 0 && self.collectionView.numberOfItems(inSection: 0) > 0 else { return true }
+        guard
+            let collectionView = self.collectionView,
+            collectionView.numberOfSections > 0
+                && collectionView.numberOfItems(inSection: 0) > 0
+        else { return true }
         let firstIndexPath = IndexPath(item: 0, section: 0)
         return self.isIndexPathVisible(firstIndexPath, atEdge: .top)
     }
 
     public func isCloseToBottom() -> Bool {
-        guard self.collectionView.contentSize.height > 0 else { return true }
-        return (self.visibleRect().maxY / self.collectionView.contentSize.height) > (1 - self.constants.autoloadingFractionalThreshold)
+        guard
+            let collectionView = self.collectionView,
+            collectionView.contentSize.height > 0
+        else { return true }
+        return (self.visibleRect().maxY / collectionView.contentSize.height) > (1 - self.constants.autoloadingFractionalThreshold)
     }
 
     public func isCloseToTop() -> Bool {
-        guard self.collectionView.contentSize.height > 0 else { return true }
-        return (self.visibleRect().minY / self.collectionView.contentSize.height) < self.constants.autoloadingFractionalThreshold
+        guard
+            let collectionView = self.collectionView,
+            collectionView.contentSize.height > 0
+            else { return true }
+        return (self.visibleRect().minY / collectionView.contentSize.height) < self.constants.autoloadingFractionalThreshold
     }
 
     public func isIndexPathVisible(_ indexPath: IndexPath, atEdge edge: CellVerticalEdge) -> Bool {
-        if let attributes = self.collectionView.collectionViewLayout.layoutAttributesForItem(at: indexPath) {
+        guard
+            let collectionView = self.collectionView,
+            let attributes = collectionView.collectionViewLayout.layoutAttributesForItem(at: indexPath)
+        else { return false }
             let visibleRect = self.visibleRect()
             let intersection = visibleRect.intersection(attributes.frame)
             if edge == .top {
@@ -68,47 +85,48 @@ extension BaseChatViewController {
             } else {
                 return abs(intersection.maxY - attributes.frame.maxY) < CGFloat.bma_epsilon
             }
-        }
-        return false
     }
 
     public func visibleRect() -> CGRect {
-        let contentInset = self.collectionView.contentInset
-        let collectionViewBounds = self.collectionView.bounds
-        let contentSize = self.collectionView.collectionViewLayout.collectionViewContentSize
-        return CGRect(x: CGFloat(0), y: self.collectionView.contentOffset.y + contentInset.top, width: collectionViewBounds.width, height: min(contentSize.height, collectionViewBounds.height - contentInset.top - contentInset.bottom))
+        guard let collectionView = self.collectionView else { return CGRect.zero }
+        let contentInset = collectionView.contentInset
+        let collectionViewBounds = collectionView.bounds
+        let contentSize = collectionView.collectionViewLayout.collectionViewContentSize
+        return CGRect(x: CGFloat(0), y: collectionView.contentOffset.y + contentInset.top, width: collectionViewBounds.width, height: min(contentSize.height, collectionViewBounds.height - contentInset.top - contentInset.bottom))
     }
 
     @objc
     open func scrollToBottom(animated: Bool) {
+        guard let collectionView = self.collectionView else { return }
         // Cancel current scrolling
-        self.collectionView.setContentOffset(self.collectionView.contentOffset, animated: false)
+        collectionView.setContentOffset(collectionView.contentOffset, animated: false)
 
         // Note that we don't rely on collectionView's contentSize. This is because it won't be valid after performBatchUpdates or reloadData
         // After reload data, collectionViewLayout.collectionViewContentSize won't be even valid, so you may want to refresh the layout manually
-        let offsetY = max(-self.collectionView.contentInset.top, self.collectionView.collectionViewLayout.collectionViewContentSize.height - self.collectionView.bounds.height + self.collectionView.contentInset.bottom)
+        let offsetY = max(-collectionView.contentInset.top, collectionView.collectionViewLayout.collectionViewContentSize.height - collectionView.bounds.height + collectionView.contentInset.bottom)
 
         // Don't use setContentOffset(:animated). If animated, contentOffset property will be updated along with the animation for each frame update
         // If a message is inserted while scrolling is happening (as in very fast typing), we want to take the "final" content offset (not the "real time" one) to check if we should scroll to bottom again
         if animated {
             UIView.animate(withDuration: self.constants.updatesAnimationDuration, animations: { () -> Void in
-                self.collectionView.contentOffset = CGPoint(x: 0, y: offsetY)
+                collectionView.contentOffset = CGPoint(x: 0, y: offsetY)
             })
         } else {
-            self.collectionView.contentOffset = CGPoint(x: 0, y: offsetY)
+            collectionView.contentOffset = CGPoint(x: 0, y: offsetY)
         }
     }
 
     public func scrollToPreservePosition(oldRefRect: CGRect?, newRefRect: CGRect?) {
-        guard let oldRefRect = oldRefRect, let newRefRect = newRefRect else {
+        guard let collectionView = self.collectionView, let oldRefRect = oldRefRect, let newRefRect = newRefRect else {
             return
         }
         let diffY = newRefRect.minY - oldRefRect.minY
-        self.collectionView.contentOffset = CGPoint(x: 0, y: self.collectionView.contentOffset.y + diffY)
+        collectionView.contentOffset = CGPoint(x: 0, y: collectionView.contentOffset.y + diffY)
     }
 
     open func scrollViewDidScroll(_ scrollView: UIScrollView) {
-        if self.collectionView.isDragging {
+        guard let collectionView = self.collectionView else { return }
+        if collectionView.isDragging {
             self.autoLoadMoreContentIfNeeded()
         }
     }

--- a/Chatto/Source/ChatController/BaseChatViewController+Scrolling.swift
+++ b/Chatto/Source/ChatController/BaseChatViewController+Scrolling.swift
@@ -36,11 +36,8 @@ extension CGFloat {
 extension BaseChatViewController {
 
     public func isScrolledAtBottom() -> Bool {
-        guard
-            let collectionView = self.collectionView,
-            collectionView.numberOfSections > 0
-                && collectionView.numberOfItems(inSection: 0) > 0
-        else { return true }
+        guard let collectionView = self.collectionView else { return true }
+        guard collectionView.numberOfSections > 0 && collectionView.numberOfItems(inSection: 0) > 0 else { return true }
         let sectionIndex = collectionView.numberOfSections - 1
         let itemIndex = collectionView.numberOfItems(inSection: sectionIndex) - 1
         let lastIndexPath = IndexPath(item: itemIndex, section: sectionIndex)
@@ -48,43 +45,34 @@ extension BaseChatViewController {
     }
 
     public func isScrolledAtTop() -> Bool {
-        guard
-            let collectionView = self.collectionView,
-            collectionView.numberOfSections > 0
-                && collectionView.numberOfItems(inSection: 0) > 0
-        else { return true }
+        guard let collectionView = self.collectionView else { return true }
+        guard collectionView.numberOfSections > 0 && collectionView.numberOfItems(inSection: 0) > 0 else { return true }
         let firstIndexPath = IndexPath(item: 0, section: 0)
         return self.isIndexPathVisible(firstIndexPath, atEdge: .top)
     }
 
     public func isCloseToBottom() -> Bool {
-        guard
-            let collectionView = self.collectionView,
-            collectionView.contentSize.height > 0
-        else { return true }
+        guard let collectionView = self.collectionView else { return true }
+        guard collectionView.contentSize.height > 0 else { return true }
         return (self.visibleRect().maxY / collectionView.contentSize.height) > (1 - self.constants.autoloadingFractionalThreshold)
     }
 
     public func isCloseToTop() -> Bool {
-        guard
-            let collectionView = self.collectionView,
-            collectionView.contentSize.height > 0
-            else { return true }
+        guard let collectionView = self.collectionView else { return true }
+        guard collectionView.contentSize.height > 0 else { return true }
         return (self.visibleRect().minY / collectionView.contentSize.height) < self.constants.autoloadingFractionalThreshold
     }
 
     public func isIndexPathVisible(_ indexPath: IndexPath, atEdge edge: CellVerticalEdge) -> Bool {
-        guard
-            let collectionView = self.collectionView,
-            let attributes = collectionView.collectionViewLayout.layoutAttributesForItem(at: indexPath)
-        else { return false }
-            let visibleRect = self.visibleRect()
-            let intersection = visibleRect.intersection(attributes.frame)
-            if edge == .top {
-                return abs(intersection.minY - attributes.frame.minY) < CGFloat.bma_epsilon
-            } else {
-                return abs(intersection.maxY - attributes.frame.maxY) < CGFloat.bma_epsilon
-            }
+        guard let collectionView = self.collectionView else { return true }
+        guard let attributes = collectionView.collectionViewLayout.layoutAttributesForItem(at: indexPath) else { return false }
+        let visibleRect = self.visibleRect()
+        let intersection = visibleRect.intersection(attributes.frame)
+        if edge == .top {
+            return abs(intersection.minY - attributes.frame.minY) < CGFloat.bma_epsilon
+        } else {
+            return abs(intersection.maxY - attributes.frame.maxY) < CGFloat.bma_epsilon
+        }
     }
 
     public func visibleRect() -> CGRect {
@@ -117,7 +105,8 @@ extension BaseChatViewController {
     }
 
     public func scrollToPreservePosition(oldRefRect: CGRect?, newRefRect: CGRect?) {
-        guard let collectionView = self.collectionView, let oldRefRect = oldRefRect, let newRefRect = newRefRect else {
+        guard let collectionView = self.collectionView else { return }
+        guard let oldRefRect = oldRefRect, let newRefRect = newRefRect else {
             return
         }
         let diffY = newRefRect.minY - oldRefRect.minY

--- a/Chatto/Source/ChatController/BaseChatViewController.swift
+++ b/Chatto/Source/ChatController/BaseChatViewController.swift
@@ -231,6 +231,7 @@ open class BaseChatViewController: UIViewController, UICollectionViewDataSource,
     }
 
     open func handleKeyboardPositionChange(bottomMargin: CGFloat, keyboardStatus: KeyboardStatus) {
+        guard self.inputContainerBottomConstraint.constant != bottomMargin else { return }
         self.isAdjustingInputContainer = true
         self.inputContainerBottomConstraint.constant = max(bottomMargin, self.bottomLayoutGuide.length)
         self.view.layoutIfNeeded()
@@ -393,9 +394,9 @@ open class BaseChatViewController: UIViewController, UICollectionViewDataSource,
 extension BaseChatViewController { // Rotation
 
     open override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
+        super.viewWillTransition(to: size, with: coordinator)
         guard isViewLoaded else { return }
         guard let collectionView = self.collectionView else { return }
-        super.viewWillTransition(to: size, with: coordinator)
         let shouldScrollToBottom = self.isScrolledAtBottom()
         let referenceIndexPath = collectionView.indexPathsForVisibleItems.first
         let oldRect = self.rectAtIndexPath(referenceIndexPath)

--- a/Chatto/Source/ChatController/BaseChatViewController.swift
+++ b/Chatto/Source/ChatController/BaseChatViewController.swift
@@ -63,7 +63,7 @@ open class BaseChatViewController: UIViewController, UICollectionViewDataSource,
             self.setChatDataSource(newValue, triggeringUpdateType: .normal)
         }
     }
- 
+
     // If set to false messages will start appearing on top and goes down
     // If true then messages will start from bottom and goes up.
     public var placeMessagesFromBottom = false {
@@ -154,7 +154,7 @@ open class BaseChatViewController: UIViewController, UICollectionViewDataSource,
 
         self.accessoryViewRevealer = AccessoryViewRevealer(collectionView: collectionView)
         self.collectionView = collectionView
-        
+
         if !self.customPresentersConfigurationPoint {
             self.confugureCollectionViewWithPresenters()
         }
@@ -209,7 +209,7 @@ open class BaseChatViewController: UIViewController, UICollectionViewDataSource,
             } else {
                 navigatedController = self
             }
-            
+
             if navigatedController.hidesBottomBarWhenPushed && (navigationController?.viewControllers.count ?? 0) > 1 && navigationController?.viewControllers.last == navigatedController {
                 self.inputContainerBottomConstraint.constant = 0
             } else {
@@ -231,7 +231,6 @@ open class BaseChatViewController: UIViewController, UICollectionViewDataSource,
     }
 
     open func handleKeyboardPositionChange(bottomMargin: CGFloat, keyboardStatus: KeyboardStatus) {
-        guard self.inputContainerBottomConstraint.constant != bottomMargin else { return }
         self.isAdjustingInputContainer = true
         self.inputContainerBottomConstraint.constant = max(bottomMargin, self.bottomLayoutGuide.length)
         self.view.layoutIfNeeded()
@@ -256,12 +255,12 @@ open class BaseChatViewController: UIViewController, UICollectionViewDataSource,
     }
 
     public var allContentFits: Bool {
+        guard let collectionView = self.collectionView else { return false }
         let inputHeightWithKeyboard = self.view.bounds.height - self.inputContainer.frame.minY
         let insetTop = self.topLayoutGuide.length + self.layoutConfiguration.contentInsets.top
         let insetBottom = self.layoutConfiguration.contentInsets.bottom + inputHeightWithKeyboard
-        let collectionViewHeight = self.collectionView?.bounds.height ?? 0
-        let availableHeight =  collectionViewHeight - (insetTop + insetBottom)
-        let contentSize = self.collectionView?.collectionViewLayout.collectionViewContentSize ?? CGSize.zero
+        let availableHeight = collectionView.bounds.height - (insetTop + insetBottom)
+        let contentSize = collectionView.collectionViewLayout.collectionViewContentSize
         return availableHeight >= contentSize.height
     }
 
@@ -279,7 +278,7 @@ open class BaseChatViewController: UIViewController, UICollectionViewDataSource,
 
         let needToPlaceMessagesAtBottom = self.placeMessagesFromBottom && self.allContentFits
         if needToPlaceMessagesAtBottom {
-            let realContentHeight = contentSize.height + newInsetTop + newInsetBottom;
+            let realContentHeight = contentSize.height + newInsetTop + newInsetBottom
             newInsetTop += collectionView.bounds.height - realContentHeight
         }
 
@@ -322,10 +321,10 @@ open class BaseChatViewController: UIViewController, UICollectionViewDataSource,
     }
 
     func rectAtIndexPath(_ indexPath: IndexPath?) -> CGRect? {
-        if let indexPath = indexPath {
-            return self.collectionView?.collectionViewLayout.layoutAttributesForItem(at: indexPath)?.frame
-        }
-        return nil
+        guard let collectionView = self.collectionView else { return nil }
+        guard let indexPath = indexPath else { return nil }
+
+        return collectionView.collectionViewLayout.layoutAttributesForItem(at: indexPath)?.frame
     }
 
     var autoLoadingEnabled: Bool = false
@@ -394,9 +393,11 @@ open class BaseChatViewController: UIViewController, UICollectionViewDataSource,
 extension BaseChatViewController { // Rotation
 
     open override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
+        guard isViewLoaded else { return }
+        guard let collectionView = self.collectionView else { return }
         super.viewWillTransition(to: size, with: coordinator)
         let shouldScrollToBottom = self.isScrolledAtBottom()
-        let referenceIndexPath = self.collectionView?.indexPathsForVisibleItems.first
+        let referenceIndexPath = collectionView.indexPathsForVisibleItems.first
         let oldRect = self.rectAtIndexPath(referenceIndexPath)
         coordinator.animate(alongsideTransition: { (_) -> Void in
             if shouldScrollToBottom {

--- a/Chatto/Source/ChatController/BaseChatViewController.swift
+++ b/Chatto/Source/ChatController/BaseChatViewController.swift
@@ -52,7 +52,7 @@ open class BaseChatViewController: UIViewController, UICollectionViewDataSource,
 
     open var customPresentersConfigurationPoint = false // If true then confugureCollectionViewWithPresenters() will not be called in viewDidLoad() method and has to be called manually
 
-    public private(set) var collectionView: UICollectionView!
+    public private(set) var collectionView: UICollectionView?
     public final internal(set) var chatItemCompanionCollection: ChatItemCompanionCollection = ReadOnlyOrderedDictionary(items: [])
     private var _chatDataSource: ChatDataSourceProtocol?
     public final var chatDataSource: ChatDataSourceProtocol? {
@@ -110,7 +110,7 @@ open class BaseChatViewController: UIViewController, UICollectionViewDataSource,
     }
 
     private func setupTapGestureRecognizer() {
-        self.collectionView.addGestureRecognizer(UITapGestureRecognizer(target: self, action: #selector(BaseChatViewController.userDidTapOnCollectionView)))
+        self.collectionView?.addGestureRecognizer(UITapGestureRecognizer(target: self, action: #selector(BaseChatViewController.userDidTapOnCollectionView)))
     }
 
     public var endsEditingWhenTappingOnChatBackground = true
@@ -132,28 +132,29 @@ open class BaseChatViewController: UIViewController, UICollectionViewDataSource,
     }
 
     private func addCollectionView() {
-        self.collectionView = UICollectionView(frame: CGRect.zero, collectionViewLayout: self.createCollectionViewLayout())
-        self.collectionView.contentInset = self.layoutConfiguration.contentInsets
-        self.collectionView.scrollIndicatorInsets = self.layoutConfiguration.scrollIndicatorInsets
-        self.collectionView.alwaysBounceVertical = true
-        self.collectionView.backgroundColor = UIColor.clear
-        self.collectionView.keyboardDismissMode = .interactive
-        self.collectionView.showsVerticalScrollIndicator = true
-        self.collectionView.showsHorizontalScrollIndicator = false
-        self.collectionView.allowsSelection = false
-        self.collectionView.translatesAutoresizingMaskIntoConstraints = false
-        self.collectionView.autoresizingMask = UIViewAutoresizing()
-        self.view.addSubview(self.collectionView)
-        self.view.addConstraint(NSLayoutConstraint(item: self.view, attribute: .top, relatedBy: .equal, toItem: self.collectionView, attribute: .top, multiplier: 1, constant: 0))
-        self.view.addConstraint(NSLayoutConstraint(item: self.view, attribute: .leading, relatedBy: .equal, toItem: self.collectionView, attribute: .leading, multiplier: 1, constant: 0))
-        self.view.addConstraint(NSLayoutConstraint(item: self.view, attribute: .bottom, relatedBy: .equal, toItem: self.collectionView, attribute: .bottom, multiplier: 1, constant: 0))
-        self.view.addConstraint(NSLayoutConstraint(item: self.view, attribute: .trailing, relatedBy: .equal, toItem: self.collectionView, attribute: .trailing, multiplier: 1, constant: 0))
-        self.collectionView.dataSource = self
-        self.collectionView.delegate = self
-        self.collectionView.chatto_setContentInsetAdjustment(enabled: false, in: self)
+        let collectionView = UICollectionView(frame: CGRect.zero, collectionViewLayout: self.createCollectionViewLayout())
+        collectionView.contentInset = self.layoutConfiguration.contentInsets
+        collectionView.scrollIndicatorInsets = self.layoutConfiguration.scrollIndicatorInsets
+        collectionView.alwaysBounceVertical = true
+        collectionView.backgroundColor = UIColor.clear
+        collectionView.keyboardDismissMode = .interactive
+        collectionView.showsVerticalScrollIndicator = true
+        collectionView.showsHorizontalScrollIndicator = false
+        collectionView.allowsSelection = false
+        collectionView.translatesAutoresizingMaskIntoConstraints = false
+        collectionView.autoresizingMask = UIViewAutoresizing()
+        self.view.addSubview(collectionView)
+        self.view.addConstraint(NSLayoutConstraint(item: self.view, attribute: .top, relatedBy: .equal, toItem: collectionView, attribute: .top, multiplier: 1, constant: 0))
+        self.view.addConstraint(NSLayoutConstraint(item: self.view, attribute: .leading, relatedBy: .equal, toItem: collectionView, attribute: .leading, multiplier: 1, constant: 0))
+        self.view.addConstraint(NSLayoutConstraint(item: self.view, attribute: .bottom, relatedBy: .equal, toItem: collectionView, attribute: .bottom, multiplier: 1, constant: 0))
+        self.view.addConstraint(NSLayoutConstraint(item: self.view, attribute: .trailing, relatedBy: .equal, toItem: collectionView, attribute: .trailing, multiplier: 1, constant: 0))
+        collectionView.dataSource = self
+        collectionView.delegate = self
+        collectionView.chatto_setContentInsetAdjustment(enabled: false, in: self)
 
-        self.accessoryViewRevealer = AccessoryViewRevealer(collectionView: self.collectionView)
-
+        self.accessoryViewRevealer = AccessoryViewRevealer(collectionView: collectionView)
+        self.collectionView = collectionView
+        
         if !self.customPresentersConfigurationPoint {
             self.confugureCollectionViewWithPresenters()
         }
@@ -258,49 +259,51 @@ open class BaseChatViewController: UIViewController, UICollectionViewDataSource,
         let inputHeightWithKeyboard = self.view.bounds.height - self.inputContainer.frame.minY
         let insetTop = self.topLayoutGuide.length + self.layoutConfiguration.contentInsets.top
         let insetBottom = self.layoutConfiguration.contentInsets.bottom + inputHeightWithKeyboard
-        let availableHeight = self.collectionView.bounds.height - (insetTop + insetBottom)
-        let contentSize = self.collectionView.collectionViewLayout.collectionViewContentSize
+        let collectionViewHeight = self.collectionView?.bounds.height ?? 0
+        let availableHeight =  collectionViewHeight - (insetTop + insetBottom)
+        let contentSize = self.collectionView?.collectionViewLayout.collectionViewContentSize ?? CGSize.zero
         return availableHeight >= contentSize.height
     }
 
     func adjustCollectionViewInsets(shouldUpdateContentOffset: Bool) {
-        let isInteracting = self.collectionView.panGestureRecognizer.numberOfTouches > 0
-        let isBouncingAtTop = isInteracting && self.collectionView.contentOffset.y < -self.collectionView.contentInset.top
+        guard let collectionView = self.collectionView else { return }
+        let isInteracting = collectionView.panGestureRecognizer.numberOfTouches > 0
+        let isBouncingAtTop = isInteracting && collectionView.contentOffset.y < -collectionView.contentInset.top
         if !self.placeMessagesFromBottom && isBouncingAtTop { return }
 
         let inputHeightWithKeyboard = self.view.bounds.height - self.inputContainer.frame.minY
         let newInsetBottom = self.layoutConfiguration.contentInsets.bottom + inputHeightWithKeyboard
-        let insetBottomDiff = newInsetBottom - self.collectionView.contentInset.bottom
+        let insetBottomDiff = newInsetBottom - collectionView.contentInset.bottom
         var newInsetTop = self.topLayoutGuide.length + self.layoutConfiguration.contentInsets.top
-        let contentSize = self.collectionView.collectionViewLayout.collectionViewContentSize
+        let contentSize = collectionView.collectionViewLayout.collectionViewContentSize
 
         let needToPlaceMessagesAtBottom = self.placeMessagesFromBottom && self.allContentFits
         if needToPlaceMessagesAtBottom {
             let realContentHeight = contentSize.height + newInsetTop + newInsetBottom;
-            newInsetTop += self.collectionView.bounds.height - realContentHeight
+            newInsetTop += collectionView.bounds.height - realContentHeight
         }
 
-        let insetTopDiff = newInsetTop - self.collectionView.contentInset.top
+        let insetTopDiff = newInsetTop - collectionView.contentInset.top
         let needToUpdateContentInset = self.placeMessagesFromBottom && (insetTopDiff != 0 || insetBottomDiff != 0)
 
-        let prevContentOffsetY = self.collectionView.contentOffset.y
+        let prevContentOffsetY = collectionView.contentOffset.y
 
         let newContentOffsetY: CGFloat = {
             let minOffset = -newInsetTop
-            let maxOffset = contentSize.height - (self.collectionView.bounds.height - newInsetBottom)
+            let maxOffset = contentSize.height - (collectionView.bounds.height - newInsetBottom)
             let targetOffset = prevContentOffsetY + insetBottomDiff
             return max(min(maxOffset, targetOffset), minOffset)
         }()
 
-        self.collectionView.contentInset = {
-            var currentInsets = self.collectionView.contentInset
+        collectionView.contentInset = {
+            var currentInsets = collectionView.contentInset
             currentInsets.bottom = newInsetBottom
             currentInsets.top = newInsetTop
             return currentInsets
         }()
 
-        self.collectionView.scrollIndicatorInsets = {
-            var currentInsets = self.collectionView.scrollIndicatorInsets
+        collectionView.scrollIndicatorInsets = {
+            var currentInsets = collectionView.scrollIndicatorInsets
             currentInsets.bottom = self.layoutConfiguration.scrollIndicatorInsets.bottom + inputHeightWithKeyboard
             currentInsets.top = self.topLayoutGuide.length + self.layoutConfiguration.scrollIndicatorInsets.top
             return currentInsets
@@ -310,17 +313,17 @@ open class BaseChatViewController: UIViewController, UICollectionViewDataSource,
 
         let inputIsAtBottom = self.view.bounds.maxY - self.inputContainer.frame.maxY <= 0
         if isInteracting && (needToPlaceMessagesAtBottom || needToUpdateContentInset) {
-            self.collectionView.contentOffset.y = prevContentOffsetY
+            collectionView.contentOffset.y = prevContentOffsetY
         } else if self.allContentFits {
-            self.collectionView.contentOffset.y = -self.collectionView.contentInset.top
+            collectionView.contentOffset.y = -collectionView.contentInset.top
         } else if !isInteracting || inputIsAtBottom {
-            self.collectionView.contentOffset.y = newContentOffsetY
+            collectionView.contentOffset.y = newContentOffsetY
         }
     }
 
     func rectAtIndexPath(_ indexPath: IndexPath?) -> CGRect? {
         if let indexPath = indexPath {
-            return self.collectionView.collectionViewLayout.layoutAttributesForItem(at: indexPath)?.frame
+            return self.collectionView?.collectionViewLayout.layoutAttributesForItem(at: indexPath)?.frame
         }
         return nil
     }
@@ -393,7 +396,7 @@ extension BaseChatViewController { // Rotation
     open override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
         super.viewWillTransition(to: size, with: coordinator)
         let shouldScrollToBottom = self.isScrolledAtBottom()
-        let referenceIndexPath = self.collectionView.indexPathsForVisibleItems.first
+        let referenceIndexPath = self.collectionView?.indexPathsForVisibleItems.first
         let oldRect = self.rectAtIndexPath(referenceIndexPath)
         coordinator.animate(alongsideTransition: { (_) -> Void in
             if shouldScrollToBottom {

--- a/Chatto/Tests/ChatController/BaseChatViewControllerTests.swift
+++ b/Chatto/Tests/ChatController/BaseChatViewControllerTests.swift
@@ -27,10 +27,17 @@ import XCTest
 
 class ChatViewControllerTests: XCTestCase {
 
+    func testThat_WhenChatViewControllerInitated_ThenViewsIsNotLoaded() {
+        let controller = TesteableChatViewController()
+        XCTAssertFalse(controller.isViewLoaded)
+        XCTAssertNil(controller.collectionView)
+    }
+
     func testThat_GivenNoDataSource_ThenChatViewControllerLoadsCorrectly() {
         let controller = TesteableChatViewController()
         self.fakeDidAppearAndLayout(controller: controller)
         XCTAssertNotNil(controller.view)
+        XCTAssertNotNil(controller.collectionView)
     }
 
     func testThat_GivenEmptyDataSource_ThenChatViewControllerLoadsCorrectly() {
@@ -38,6 +45,7 @@ class ChatViewControllerTests: XCTestCase {
         controller.chatDataSource = FakeDataSource()
         self.fakeDidAppearAndLayout(controller: controller)
         XCTAssertNotNil(controller.view)
+        XCTAssertNotNil(controller.collectionView)
     }
 
     func testThat_GivenDataSourceWithItemsAndNoPresenters_ThenChatViewControllerLoadsCorrectly() {
@@ -47,7 +55,9 @@ class ChatViewControllerTests: XCTestCase {
         controller.chatDataSource = fakeDataSource
         self.fakeDidAppearAndLayout(controller: controller)
         XCTAssertNotNil(controller.view)
-        XCTAssertEqual(2, controller.collectionView(controller.collectionView, numberOfItemsInSection: 0))
+        XCTAssertNotNil(controller.collectionView)
+        let collectionView = controller.collectionView!
+        XCTAssertEqual(2, controller.collectionView(collectionView, numberOfItemsInSection: 0))
     }
 
     func testThat_PresentersAreCreated () {
@@ -68,6 +78,8 @@ class ChatViewControllerTests: XCTestCase {
         fakeDataSource.chatItems = createFakeChatItems(count: 2)
         controller.chatDataSource = fakeDataSource
         self.fakeDidAppearAndLayout(controller: controller)
+        XCTAssertNotNil(controller.collectionView)
+        let collectionView = controller.collectionView!
         fakeDataSource.chatItems = createFakeChatItems(count: 3)
         fakeDataSource.delegate?.chatDataSourceDidUpdate(fakeDataSource)
         controller.updateQueue.addTask { (completion) -> Void in
@@ -75,7 +87,7 @@ class ChatViewControllerTests: XCTestCase {
             completion()
         }
         self.waitForExpectations(timeout: 1) { (_) -> Void in
-            XCTAssertEqual(3, controller.collectionView(controller.collectionView, numberOfItemsInSection: 0))
+            XCTAssertEqual(3, controller.collectionView(collectionView, numberOfItemsInSection: 0))
         }
     }
 
@@ -98,10 +110,11 @@ class ChatViewControllerTests: XCTestCase {
         fakeDataSource.chatItems = createFakeChatItems(count: 2000)
         controller.chatDataSource = fakeDataSource
         self.fakeDidAppearAndLayout(controller: controller)
+        let collectionView = controller.collectionView!
         controller.updateQueue.addTask { (completion) -> Void in
             fakeDataSource.hasMorePrevious = true
-            controller.collectionView.contentOffset = CGPoint.zero
-            controller.scrollViewDidScrollToTop(controller.collectionView)
+            collectionView.contentOffset = CGPoint.zero
+            controller.scrollViewDidScrollToTop(collectionView)
             completion()
             asyncExpectation.fulfill()
         }
@@ -118,7 +131,8 @@ class ChatViewControllerTests: XCTestCase {
         fakeDataSource.chatItems = createFakeChatItems(count: 2000)
         controller.chatDataSource = fakeDataSource
         self.fakeDidAppearAndLayout(controller: controller)
-        let contentOffset = controller.collectionView.contentOffset
+        let collectionView = controller.collectionView!
+        let contentOffset = collectionView.contentOffset
         fakeDataSource.hasMoreNext = true
         fakeDataSource.chatItemsForLoadNext = createFakeChatItems(count: 3000)
         controller.autoLoadingEnabled = true // It will be false until first update finishes, let's fake it
@@ -130,8 +144,8 @@ class ChatViewControllerTests: XCTestCase {
         }
 
         self.waitForExpectations(timeout: 1) { (_) -> Void in
-            XCTAssertEqual(3000, controller.collectionView(controller.collectionView, numberOfItemsInSection: 0))
-            XCTAssertEqual(contentOffset, controller.collectionView.contentOffset)
+            XCTAssertEqual(3000, controller.collectionView(collectionView, numberOfItemsInSection: 0))
+            XCTAssertEqual(contentOffset, collectionView.contentOffset)
         }
     }
 


### PR DESCRIPTION
Force unwrap leads to crash in cases when ViewController addresses to collectionview before it was loaded. e.g. You can try to rotate device when chat is initialized inside unopened tab inside UITabBarController.