### PR TITLE
Fix potential crash in SendingStatusPresenter

### DIFF
--- a/ChattoApp/ChattoApp/Source/Chat Items/Sending status/SendingStatusPresenter.swift
+++ b/ChattoApp/ChattoApp/Source/Chat Items/Sending status/SendingStatusPresenter.swift
@@ -70,7 +70,7 @@ class SendingStatusPresenter: ChatItemPresenterProtocol {
     }
 
     static func registerCells(_ collectionView: UICollectionView) {
-        collectionView.register(UINib(nibName: "SendingStatusCollectionViewCell", bundle: nil), forCellWithReuseIdentifier: "SendingStatusCollectionViewCell")
+        collectionView.register(UINib(nibName: "SendingStatusCollectionViewCell", bundle: Bundle(for: self)), forCellWithReuseIdentifier: "SendingStatusCollectionViewCell")
     }
 
     func dequeueCell(collectionView: UICollectionView, indexPath: IndexPath) -> UICollectionViewCell {


### PR DESCRIPTION
If SendingStatusPresenter included as a framework (i.e. it's XIB is *not* in the main bundle) it will crash on line 73