### PR TITLE
Move initialization of PHPhotoLibrary and PHCachingImageManager to background

### DIFF
--- a/ChattoAdditions/Source/Input/Photos/Photo/PhotosInputDataProvider.swift
+++ b/ChattoAdditions/Source/Input/Photos/Photo/PhotosInputDataProvider.swift
@@ -93,14 +93,8 @@ final class PhotosInputDataProvider: NSObject, PhotosInputDataProviderProtocol, 
             PHPhotoLibrary.shared().register(self)
 
             DispatchQueue.main.async(execute: { [weak self] in
-                guard let self = self else {
-                    DispatchQueue.main.async(execute: completion)
-                    return
-                }
-
-                self.fetchResult = fetchResult
-                self.imageManager = imageManager
-
+                self?.fetchResult = fetchResult
+                self?.imageManager = imageManager
                 completion()
             })
         }
@@ -132,8 +126,8 @@ final class PhotosInputDataProvider: NSObject, PhotosInputDataProviderProtocol, 
             }
             request.handleCompletion(with: result)
         }
-        request.cancelBlock = { [weak self] in
-            self?.imageManager?.cancelImageRequest(requestId)
+        request.cancelBlock = { [weak imageManager] in
+            imageManager?.cancelImageRequest(requestId)
         }
         request.requestId = requestId
         return request

--- a/ChattoAdditions/Source/Input/Photos/Photo/PhotosInputDataProvider.swift
+++ b/ChattoAdditions/Source/Input/Photos/Photo/PhotosInputDataProvider.swift
@@ -60,50 +60,70 @@ private class PhotosInputDataProviderImageRequest: PhotosInputDataProviderImageR
 @objc
 final class PhotosInputDataProvider: NSObject, PhotosInputDataProviderProtocol, PHPhotoLibraryChangeObserver {
     weak var delegate: PhotosInputDataProviderDelegate?
-    private var imageManager = PHCachingImageManager()
-    private var fetchResult: PHFetchResult<PHAsset>!
+    private var imageManager: PHCachingImageManager?
+    private var fetchResult: PHFetchResult<PHAsset>?
     private var fullImageRequests = [PHAsset: PhotosInputDataProviderImageRequestProtocol]()
-    override init() {
-        func fetchOptions(_ predicate: NSPredicate?) -> PHFetchOptions {
-            let options = PHFetchOptions()
-            options.sortDescriptors = [ NSSortDescriptor(key: "creationDate", ascending: false) ]
-            options.predicate = predicate
-            return options
-        }
-
-        if let userLibraryCollection = PHAssetCollection.fetchAssetCollections(with: .smartAlbum, subtype: .smartAlbumUserLibrary, options: nil).firstObject {
-            self.fetchResult = PHAsset.fetchAssets(in: userLibraryCollection, options: fetchOptions(NSPredicate(format: "mediaType = \(PHAssetMediaType.image.rawValue)")))
-        } else {
-            self.fetchResult = PHAsset.fetchAssets(with: .image, options: fetchOptions(nil))
-        }
-        super.init()
-    }
 
     deinit {
         PHPhotoLibrary.shared().unregisterChangeObserver(self)
     }
 
-    var count: Int {
-        return self.fetchResult.count
+    func prepare(_ completion: @escaping () -> Void) {
+        DispatchQueue.global(qos: .userInitiated).async { [weak self] in
+            guard let self = self else {
+                DispatchQueue.main.async(execute: completion)
+                return
+            }
+
+            func fetchOptions(_ predicate: NSPredicate?) -> PHFetchOptions {
+                let options = PHFetchOptions()
+                options.sortDescriptors = [ NSSortDescriptor(key: "creationDate", ascending: false) ]
+                options.predicate = predicate
+                return options
+            }
+
+            let fetchResult: PHFetchResult<PHAsset> = {
+                if let userLibraryCollection = PHAssetCollection.fetchAssetCollections(with: .smartAlbum, subtype: .smartAlbumUserLibrary, options: nil).firstObject {
+                    return PHAsset.fetchAssets(in: userLibraryCollection, options: fetchOptions(NSPredicate(format: "mediaType = \(PHAssetMediaType.image.rawValue)")))
+                } else {
+                    return PHAsset.fetchAssets(with: .image, options: fetchOptions(nil))
+                }
+            }()
+            let imageManager = PHCachingImageManager()
+            PHPhotoLibrary.shared().register(self)
+
+            DispatchQueue.main.async(execute: { [weak self] in
+                guard let self = self else {
+                    DispatchQueue.main.async(execute: completion)
+                    return
+                }
+
+                self.fetchResult = fetchResult
+                self.imageManager = imageManager
+
+                completion()
+            })
+        }
     }
 
-    func prepare() {
-        DispatchQueue.global(qos: .userInitiated).async { [weak self] in
-            guard let self = self else { return }
-            PHPhotoLibrary.shared().register(self)
-        }
+    var count: Int {
+        return self.fetchResult?.count ?? 0
     }
 
     func requestPreviewImage(at index: Int,
                              targetSize: CGSize,
                              completion: @escaping PhotosInputDataProviderCompletion) -> PhotosInputDataProviderImageRequestProtocol {
-        assert(index >= 0 && index < self.fetchResult.count, "Index out of bounds")
-        let asset = self.fetchResult[index]
+        guard let fetchResult = self.fetchResult, let imageManager = self.imageManager else {
+            assertionFailure("PhotosInputDataProvider is not prepared")
+            return PhotosInputDataProviderImageRequest()
+        }
+        assert(index >= 0 && index < self.count, "Index out of bounds")
+        let asset = fetchResult[index]
         let request = PhotosInputDataProviderImageRequest()
         request.observeProgress(with: nil, completion: completion)
         let options = self.makePreviewRequestOptions()
         var requestId: Int32 = -1
-        requestId = self.imageManager.requestImage(for: asset, targetSize: targetSize, contentMode: .aspectFill, options: options) { (image, info) in
+        requestId = imageManager.requestImage(for: asset, targetSize: targetSize, contentMode: .aspectFill, options: options) { (image, info) in
             let result: PhotosInputDataProviderResult
             if let image = image {
                 result = .success(image)
@@ -113,7 +133,7 @@ final class PhotosInputDataProvider: NSObject, PhotosInputDataProviderProtocol, 
             request.handleCompletion(with: result)
         }
         request.cancelBlock = { [weak self] in
-            self?.imageManager.cancelImageRequest(requestId)
+            self?.imageManager?.cancelImageRequest(requestId)
         }
         request.requestId = requestId
         return request
@@ -122,11 +142,15 @@ final class PhotosInputDataProvider: NSObject, PhotosInputDataProviderProtocol, 
     func requestFullImage(at index: Int,
                           progressHandler: PhotosInputDataProviderProgressHandler?,
                           completion: @escaping PhotosInputDataProviderCompletion) -> PhotosInputDataProviderImageRequestProtocol {
-        assert(index >= 0 && index < self.fetchResult.count, "Index out of bounds")
+        guard let fetchResult = self.fetchResult, let imageManager = self.imageManager else {
+            assertionFailure("PhotosInputDataProvider is not prepared")
+            return PhotosInputDataProviderImageRequest()
+        }
+        assert(index >= 0 && index < self.count, "Index out of bounds")
         if let existedRequest = self.fullImageRequest(at: index) {
             return existedRequest
         } else {
-            let asset = self.fetchResult[index]
+            let asset = fetchResult[index]
             let request = PhotosInputDataProviderImageRequest()
             request.observeProgress(with: progressHandler, completion: completion)
             let options = self.makeFullImageRequestOptions()
@@ -137,7 +161,7 @@ final class PhotosInputDataProvider: NSObject, PhotosInputDataProviderProtocol, 
             }
             var requestId: Int32 = -1
             self.fullImageRequests[asset] = request
-            requestId = self.imageManager.requestImageData(for: asset, options: options, resultHandler: { [weak self] (data, _, _, info) in
+            requestId = imageManager.requestImageData(for: asset, options: options, resultHandler: { [weak self] (data, _, _, info) in
                 guard let sSelf = self else { return }
                 let result: PhotosInputDataProviderResult
                 if let data = data, let image = UIImage(data: data) {
@@ -158,14 +182,22 @@ final class PhotosInputDataProvider: NSObject, PhotosInputDataProviderProtocol, 
     }
 
     func fullImageRequest(at index: Int) -> PhotosInputDataProviderImageRequestProtocol? {
-        assert(index >= 0 && index < self.fetchResult.count, "Index out of bounds")
-        let asset = self.fetchResult[index]
+        guard let fetchResult = self.fetchResult else {
+            assertionFailure("PhotosInputDataProvider is not prepared")
+            return nil
+        }
+        assert(index >= 0 && index < self.count, "Index out of bounds")
+        let asset = fetchResult[index]
         return self.fullImageRequests[asset]
     }
 
     func cancelFullImageRequest(_ request: PhotosInputDataProviderImageRequestProtocol) {
+        guard let imageManager = self.imageManager else {
+            assertionFailure("PhotosInputDataProvider is not prepared")
+            return
+        }
         assert(Thread.isMainThread, "Cancel function is called not on Main Thread. It's not a thread-safe.")
-        self.imageManager.cancelImageRequest(request.requestId)
+        imageManager.cancelImageRequest(request.requestId)
         if let assetAndRequestPair = self.fullImageRequests.first(where: { $0.value === request }) {
             self.fullImageRequests[assetAndRequestPair.key] = nil
         }
@@ -189,9 +221,9 @@ final class PhotosInputDataProvider: NSObject, PhotosInputDataProviderProtocol, 
     func photoLibraryDidChange(_ changeInstance: PHChange) {
         // Photos may call this method on a background queue; switch to the main queue to update the UI.
         DispatchQueue.main.async { [weak self]  in
-            guard let sSelf = self else { return }
+            guard let sSelf = self, let fetchResult = sSelf.fetchResult else { return }
 
-            if let changeDetails = changeInstance.changeDetails(for: sSelf.fetchResult) {
+            if let changeDetails = changeInstance.changeDetails(for: fetchResult) {
                 let updateBlock = { () -> Void in
                     self?.fetchResult = changeDetails.fetchResultAfterChanges
                 }

--- a/ChattoAdditions/Source/Input/Photos/Photo/PhotosInputDataProvider.swift
+++ b/ChattoAdditions/Source/Input/Photos/Photo/PhotosInputDataProvider.swift
@@ -77,7 +77,6 @@ final class PhotosInputDataProvider: NSObject, PhotosInputDataProviderProtocol, 
             self.fetchResult = PHAsset.fetchAssets(with: .image, options: fetchOptions(nil))
         }
         super.init()
-        PHPhotoLibrary.shared().register(self)
     }
 
     deinit {
@@ -86,6 +85,13 @@ final class PhotosInputDataProvider: NSObject, PhotosInputDataProviderProtocol, 
 
     var count: Int {
         return self.fetchResult.count
+    }
+
+    func prepare() {
+        DispatchQueue.global(qos: .userInitiated).async { [weak self] in
+            guard let self = self else { return }
+            PHPhotoLibrary.shared().register(self)
+        }
     }
 
     func requestPreviewImage(at index: Int,

--- a/ChattoAdditions/Source/Input/Photos/PhotosInputView.swift
+++ b/ChattoAdditions/Source/Input/Photos/PhotosInputView.swift
@@ -159,17 +159,19 @@ public final class PhotosInputView: UIView, PhotosInputViewProtocol {
 
     private func replacePlaceholderItemsWithPhotoItems() {
         let photosDataProvider = PhotosInputDataProvider()
-        photosDataProvider.prepare()
-
-        self.collectionViewQueue.addTask { [weak self] (completion) in
+        photosDataProvider.prepare { [weak self] in
             guard let sSelf = self else { return }
 
-            let newDataProvider = PhotosInputWithPlaceholdersDataProvider(photosDataProvider: photosDataProvider, placeholdersDataProvider: PhotosInputPlaceholderDataProvider())
-            newDataProvider.delegate = sSelf
-            sSelf.dataProvider = newDataProvider
-            sSelf.cellProvider = PhotosInputCellProvider(collectionView: sSelf.collectionView, dataProvider: newDataProvider)
-            sSelf.collectionView.reloadData()
-            DispatchQueue.main.async(execute: completion)
+            sSelf.collectionViewQueue.addTask { [weak self] (completion) in
+                guard let sSelf = self else { return }
+
+                let newDataProvider = PhotosInputWithPlaceholdersDataProvider(photosDataProvider: photosDataProvider, placeholdersDataProvider: PhotosInputPlaceholderDataProvider())
+                newDataProvider.delegate = sSelf
+                sSelf.dataProvider = newDataProvider
+                sSelf.cellProvider = PhotosInputCellProvider(collectionView: sSelf.collectionView, dataProvider: newDataProvider)
+                sSelf.collectionView.reloadData()
+                DispatchQueue.main.async(execute: completion)
+            }
         }
     }
 

--- a/ChattoAdditions/Source/Input/Photos/PhotosInputView.swift
+++ b/ChattoAdditions/Source/Input/Photos/PhotosInputView.swift
@@ -158,10 +158,13 @@ public final class PhotosInputView: UIView, PhotosInputViewProtocol {
     }
 
     private func replacePlaceholderItemsWithPhotoItems() {
+        let photosDataProvider = PhotosInputDataProvider()
+        photosDataProvider.prepare()
+
         self.collectionViewQueue.addTask { [weak self] (completion) in
             guard let sSelf = self else { return }
 
-            let newDataProvider = PhotosInputWithPlaceholdersDataProvider(photosDataProvider: PhotosInputDataProvider(), placeholdersDataProvider: PhotosInputPlaceholderDataProvider())
+            let newDataProvider = PhotosInputWithPlaceholdersDataProvider(photosDataProvider: photosDataProvider, placeholdersDataProvider: PhotosInputPlaceholderDataProvider())
             newDataProvider.delegate = sSelf
             sSelf.dataProvider = newDataProvider
             sSelf.cellProvider = PhotosInputCellProvider(collectionView: sSelf.collectionView, dataProvider: newDataProvider)


### PR DESCRIPTION
We have freezes (not deadlocks) inside PHCachingImageManager initialization. According to stach trace, it might be related to PHPhotoLibrary singleton initialization. So it was moved to background thread to avoid blocking UI.

```
Thread 0:
0   libsystem_kernel.dylib               0x00000001e61db428 __semwait_signal + 8
1   libsystem_c.dylib                    0x00000001e61503cc sleep + 44
2   CoreData                             0x00000001e9181634 -[NSXPCStore sendMessage:fromContext:interrupts:error:] + 868
3   CoreData                             0x00000001e91e6c98 -[NSXPCStore loadMetadata:] + 344
4   CoreData                             0x00000001e92ca290 __91-[NSPersistentStoreCoordinator addPersistentStoreWithType:configuration:URL:options:error:]_block_invoke + 1544
5   CoreData                             0x00000001e92d6be4 gutsOfBlockToNSPersistentStoreCoordinatorPerform + 212
6   libdispatch.dylib                    0x00000001e607e484 _dispatch_client_callout + 16
7   libdispatch.dylib                    0x00000001e605e744 _dispatch_lane_barrier_sync_invoke_and_complete + 56
8   CoreData                             0x00000001e92c79d4 _perform + 200
9   CoreData                             0x00000001e9161ec8 -[NSPersistentStoreCoordinator addPersistentStoreWithType:configuration:URL:options:error:] + 384
10  PhotoLibraryServices                 0x00000001f44405e0 +[PLManagedObjectContext _configureXPCPersistentStoreCoordinator:] + 616
11  AssetsLibraryServices                0x00000001f402778c __pl_dispatch_sync_block_invoke + 36
12  libdispatch.dylib                    0x00000001e607e484 _dispatch_client_callout + 16
13  libdispatch.dylib                    0x00000001e605e744 _dispatch_lane_barrier_sync_invoke_and_complete + 56
14  AssetsLibraryServices                0x00000001f402775c pl_dispatch_sync + 68
15  PhotoLibraryServices                 0x00000001f44408bc +[PLManagedObjectContext sharedPersistentStoreCoordinator] + 152
16  PhotoLibraryServices                 0x00000001f443b560 -[PLManagedObjectContext initWithConcurrencyType:useSharedPersistentStoreCoordinator:] + 124
17  PhotoLibraryServices                 0x00000001f443b3d8 +[PLManagedObjectContext contextForPhotoLibrary:name:] + 200
18  PhotoLibraryServices                 0x00000001f435e528 -[PLPhotoLibrary _loadDatabase:] + 416
19  PhotoLibraryServices                 0x00000001f4352168 -[PLPhotoLibrary initWithTransientContext:name:pathManager:] + 580
20  Photos                               0x00000001f53b0fa4 -[PHPhotoLibrary photoLibrary] + 108
21  Photos                               0x00000001f53b1f80 -[PHPhotoLibrary registerChangeObserver:] + 168
22  Photos                               0x00000001f5391630 -[PHImageManager init] + 420
23  Photos                               0x00000001f53957bc -[PHCachingImageManager init] + 40
24  ChattoAdditions                      0x000000010360ed84 PhotosInputDataProvider.init() + 159108 (PhotosInputDataProvider.swift:63)
```