### PR TITLE
Add support for SwiftPM based dependency managers

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,22 @@
+// swift-tools-version:4.2
+import PackageDescription
+
+let package = Package(
+    name: "Chatto",
+    // platforms: [.iOS("9.0")],
+    products: [
+        .library(name: "Chatto", targets: ["Chatto"]),
+        .library(name: "ChattoAdditions", targets: ["ChattoAdditions"]),
+    ],
+    targets: [
+        .target(
+            name: "Chatto",
+            path: "Chatto/Source"
+        ),
+        .target(
+            name: "ChattoAdditions",
+            dependencies: ["Chatto"],
+            path: "ChattoAdditions/Source"
+        )
+    ]
+)

--- a/Package.swift
+++ b/Package.swift
@@ -16,7 +16,8 @@ let package = Package(
         .target(
             name: "ChattoAdditions",
             dependencies: ["Chatto"],
-            path: "ChattoAdditions/Source"
+            path: "ChattoAdditions/Source",
+            exclude: ["UI Components/CircleProgressIndicatorView"]
         )
     ]
 )

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Chatto [![Build Status](https://travis-ci.org/badoo/Chatto.svg?branch=master)](https://travis-ci.org/badoo/Chatto) [![codecov.io](https://codecov.io/github/badoo/Chatto/coverage.svg?branch=master)](https://codecov.io/github/badoo/Chatto?branch=master) [![CocoaPods Compatible](https://img.shields.io/cocoapods/v/Chatto.svg)](https://img.shields.io/cocoapods/v/Chatto.svg) [![Carthage compatible](https://img.shields.io/badge/Carthage-compatible-4BC51D.svg?style=flat)](https://github.com/Carthage/Carthage)
+# Chatto [![Build Status](https://travis-ci.org/badoo/Chatto.svg?branch=master)](https://travis-ci.org/badoo/Chatto) [![codecov.io](https://codecov.io/github/badoo/Chatto/coverage.svg?branch=master)](https://codecov.io/github/badoo/Chatto?branch=master) [![CocoaPods Compatible](https://img.shields.io/cocoapods/v/Chatto.svg)](https://img.shields.io/cocoapods/v/Chatto.svg) [![Carthage compatible](https://img.shields.io/badge/Carthage-compatible-4BC51D.svg?style=flat)](https://github.com/Carthage/Carthage) [![Accio supported](https://img.shields.io/badge/Accio-supported-0A7CF5.svg?style=flat)](https://github.com/JamitLabs/Accio)
 
 
 `Chatto` is a Swift lightweight framework to build chat applications. It's been designed to be extensible and performant. Along with `Chatto` there is `ChattoAdditions`, a companion framework which includes cells for messages and an extensible input component. You can find more details about how it was implemented in our [blog](https://techblog.badoo.com/blog/2015/12/04/how-we-made-chatto/). See them in action!
@@ -62,6 +62,28 @@ github "badoo/Chatto"
 # Swift 2.x
 github "badoo/Chatto" "swift-2"
 ```
+
+### Accio
+
+If you're using [Accio](https://github.com/JamitLabs/Accio), add the following to your `Package.swift`:
+
+```swift
+.package(url: "https://github.com/badoo/Chatto.git", .upToNextMajor(from: "3.3.1")),
+```
+
+Next, add `Chatto` and/or `ChattoAdditions` to your App targets dependencies like so:
+
+```swift
+.target(
+    name: "App",
+    dependencies: [
+        "Chatto",
+        "ChattoAdditions"
+    ]
+),
+```
+
+Then run `accio update`.
 
 ### Manually
 


### PR DESCRIPTION
This adds support for SwiftPM manifest based dependency managers. Specifically this adds support for installing via [Accio](https://github.com/JamitLabs/Accio) but will probably also work with SwiftPM once it's integrated into Xcode.

Please note that this project is part of Accio's official [integration tests](https://github.com/JamitLabs/Accio/tree/work/1000-frameworks/Demo/Shared/AppDependencies) within the [Demo project](https://github.com/JamitLabs/Accio/tree/work/1000-frameworks/Demo).