### PR TITLE
Compound bubble updates

### DIFF
--- a/ChattoAdditions/Source/Chat Items/CompoundMessage/CompoundMessagePresenter.swift
+++ b/ChattoAdditions/Source/Chat Items/CompoundMessage/CompoundMessagePresenter.swift
@@ -148,14 +148,11 @@ open class CompoundMessagePresenter<ViewModelBuilderT, InteractionHandlerT>
 
     private func makeLayoutProvider() -> CompoundBubbleLayoutProvider {
         let configuration: CompoundBubbleLayoutProvider.Configuration = {
-            let contentLayoutProviderConfigurations = self.contentFactories.map {
-                CompoundBubbleLayoutProvider.LayoutProviderConfiguration(provider: $0.createLayoutProvider(forModel: self.messageModel),
-                                                                         alignment: $0.contentAlignment(forModel: self.messageModel))
-            }
+            let contentLayoutProviders = self.contentFactories.map { $0.createLayoutProvider(forModel: self.messageModel) }
             let viewModel = self.messageViewModel
             let tailWidth = self.compoundCellStyle.tailWidth(forViewModel: viewModel)
             return CompoundBubbleLayoutProvider.Configuration(
-                layoutProviderConfigurations: contentLayoutProviderConfigurations,
+                layoutProviders: contentLayoutProviders,
                 tailWidth: tailWidth,
                 isIncoming: viewModel.isIncoming
             )

--- a/ChattoAdditions/Source/Chat Items/CompoundMessage/CompoundMessagePresenter.swift
+++ b/ChattoAdditions/Source/Chat Items/CompoundMessage/CompoundMessagePresenter.swift
@@ -36,6 +36,7 @@ open class CompoundMessagePresenter<ViewModelBuilderT, InteractionHandlerT>
 
     public let compoundCellStyle: CompoundBubbleViewStyleProtocol
     private let contentFactories: [AnyMessageContentFactory<ModelT>]
+    private let compoundCellDimensions: CompoundBubbleLayoutProvider.Dimensions
 
     private let cache: Cache<CompoundBubbleLayoutProvider.Configuration, CompoundBubbleLayoutProvider>
     private let accessibilityIdentifier: String?
@@ -52,10 +53,12 @@ open class CompoundMessagePresenter<ViewModelBuilderT, InteractionHandlerT>
         sizingCell: CompoundMessageCollectionViewCell,
         baseCellStyle: BaseMessageCollectionViewCellStyleProtocol,
         compoundCellStyle: CompoundBubbleViewStyleProtocol,
+        compoundCellDimensions: CompoundBubbleLayoutProvider.Dimensions,
         cache: Cache<CompoundBubbleLayoutProvider.Configuration, CompoundBubbleLayoutProvider>,
         accessibilityIdentifier: String?
     ) {
         self.compoundCellStyle = compoundCellStyle
+        self.compoundCellDimensions = compoundCellDimensions
         self.contentFactories = contentFactories.filter { $0.canCreateMessageContent(forModel: messageModel) }
         self.cache = cache
         self.accessibilityIdentifier = accessibilityIdentifier
@@ -154,7 +157,8 @@ open class CompoundMessagePresenter<ViewModelBuilderT, InteractionHandlerT>
             return CompoundBubbleLayoutProvider.Configuration(
                 layoutProviders: contentLayoutProviders,
                 tailWidth: tailWidth,
-                isIncoming: viewModel.isIncoming
+                isIncoming: viewModel.isIncoming,
+                dimensions: self.compoundCellDimensions
             )
         }()
         guard let provider = self.cache[configuration] else {

--- a/ChattoAdditions/Source/Chat Items/CompoundMessage/CompoundMessagePresenter.swift
+++ b/ChattoAdditions/Source/Chat Items/CompoundMessage/CompoundMessagePresenter.swift
@@ -148,11 +148,14 @@ open class CompoundMessagePresenter<ViewModelBuilderT, InteractionHandlerT>
 
     private func makeLayoutProvider() -> CompoundBubbleLayoutProvider {
         let configuration: CompoundBubbleLayoutProvider.Configuration = {
-            let contentLayoutProviders = self.contentFactories.map { $0.createLayoutProvider(forModel: self.messageModel) }
+            let contentLayoutProviderConfigurations = self.contentFactories.map {
+                CompoundBubbleLayoutProvider.LayoutProviderConfiguration(provider: $0.createLayoutProvider(forModel: self.messageModel),
+                                                                         alignment: $0.contentAlignment(forModel: self.messageModel))
+            }
             let viewModel = self.messageViewModel
             let tailWidth = self.compoundCellStyle.tailWidth(forViewModel: viewModel)
             return CompoundBubbleLayoutProvider.Configuration(
-                layoutProviders: contentLayoutProviders,
+                layoutProviderConfigurations: contentLayoutProviderConfigurations,
                 tailWidth: tailWidth,
                 isIncoming: viewModel.isIncoming
             )

--- a/ChattoAdditions/Source/Chat Items/CompoundMessage/CompoundMessagePresenterBuilder.swift
+++ b/ChattoAdditions/Source/Chat Items/CompoundMessage/CompoundMessagePresenterBuilder.swift
@@ -38,6 +38,7 @@ public final class CompoundMessagePresenterBuilder<ViewModelBuilderT, Interactio
         accessibilityIdentifier: String?,
         contentFactories: [AnyMessageContentFactory<ModelT>],
         compoundCellStyle: CompoundBubbleViewStyleProtocol = DefaultCompoundBubbleViewStyle(),
+        compoundCellDimensions: CompoundBubbleLayoutProvider.Dimensions,
         baseCellStyle: BaseMessageCollectionViewCellStyleProtocol = BaseMessageCollectionViewCellDefaultStyle()) {
         self.viewModelBuilder = viewModelBuilder
         self.interactionHandler = interactionHandler
@@ -45,6 +46,7 @@ public final class CompoundMessagePresenterBuilder<ViewModelBuilderT, Interactio
         self.accessibilityIdentifier = accessibilityIdentifier
         self.compoundCellStyle = compoundCellStyle
         self.baseCellStyle = baseCellStyle
+        self.compoundCellDimensions = compoundCellDimensions
     }
 
     public let viewModelBuilder: ViewModelBuilderT
@@ -52,6 +54,7 @@ public final class CompoundMessagePresenterBuilder<ViewModelBuilderT, Interactio
     private let contentFactories: [AnyMessageContentFactory<ModelT>]
     public let sizingCell: CompoundMessageCollectionViewCell = CompoundMessageCollectionViewCell()
     private let compoundCellStyle: CompoundBubbleViewStyleProtocol
+    private let compoundCellDimensions: CompoundBubbleLayoutProvider.Dimensions
     private let baseCellStyle: BaseMessageCollectionViewCellStyleProtocol
     private let cache = Cache<CompoundBubbleLayoutProvider.Configuration, CompoundBubbleLayoutProvider>()
     private let accessibilityIdentifier: String?
@@ -70,6 +73,7 @@ public final class CompoundMessagePresenterBuilder<ViewModelBuilderT, Interactio
             sizingCell: self.sizingCell,
             baseCellStyle: self.baseCellStyle,
             compoundCellStyle: self.compoundCellStyle,
+            compoundCellDimensions: self.compoundCellDimensions,
             cache: self.cache,
             accessibilityIdentifier: self.accessibilityIdentifier
         )

--- a/ChattoAdditions/Source/Chat Items/CompoundMessage/Content/MessageContentFactoryProtocol.swift
+++ b/ChattoAdditions/Source/Chat Items/CompoundMessage/Content/MessageContentFactoryProtocol.swift
@@ -23,11 +23,6 @@
 
 import Chatto
 
-public enum MessageContentAlignment: Hashable {
-    case leading
-    case fill
-}
-
 public protocol MessageContentFactoryProtocol {
     associatedtype Model
 
@@ -38,7 +33,6 @@ public protocol MessageContentFactoryProtocol {
     func createContentPresenter(forModel model: Model) -> MessageContentPresenterProtocol
     func createLayoutProvider(forModel model: Model) -> MessageManualLayoutProviderProtocol
     func createMenuPresenter(forModel model: Model) -> ChatItemMenuPresenterProtocol?
-    func contentAlignment(forModel model: Model) -> MessageContentAlignment
 }
 
 public extension MessageContentFactoryProtocol {
@@ -54,7 +48,6 @@ public final class AnyMessageContentFactory<Model>: MessageContentFactoryProtoco
     private let _createContentPresenter: (Model) -> MessageContentPresenterProtocol
     private let _createLayoutProvider: (Model) -> MessageManualLayoutProviderProtocol
     private let _createMenuPresenter: (Model) -> ChatItemMenuPresenterProtocol?
-    private let _contentAlignment: (Model) -> MessageContentAlignment
 
     public init<U: MessageContentFactoryProtocol>(_ base: U) where U.Model == Model {
         self.identifier = base.identifier
@@ -63,7 +56,6 @@ public final class AnyMessageContentFactory<Model>: MessageContentFactoryProtoco
         self._createContentPresenter = base.createContentPresenter
         self._createLayoutProvider = base.createLayoutProvider
         self._createMenuPresenter = base.createMenuPresenter
-        self._contentAlignment = base.contentAlignment
     }
 
     public let identifier: String
@@ -86,9 +78,5 @@ public final class AnyMessageContentFactory<Model>: MessageContentFactoryProtoco
 
     public func createMenuPresenter(forModel model: Model) -> ChatItemMenuPresenterProtocol? {
         return self._createMenuPresenter(model)
-    }
-
-    public func contentAlignment(forModel model: Model) -> MessageContentAlignment {
-        return self._contentAlignment(model)
     }
 }

--- a/ChattoAdditions/Source/Chat Items/CompoundMessage/Content/MessageContentFactoryProtocol.swift
+++ b/ChattoAdditions/Source/Chat Items/CompoundMessage/Content/MessageContentFactoryProtocol.swift
@@ -23,6 +23,11 @@
 
 import Chatto
 
+public enum MessageContentAlignment: Hashable {
+    case leading
+    case fill
+}
+
 public protocol MessageContentFactoryProtocol {
     associatedtype Model
 
@@ -33,6 +38,7 @@ public protocol MessageContentFactoryProtocol {
     func createContentPresenter(forModel model: Model) -> MessageContentPresenterProtocol
     func createLayoutProvider(forModel model: Model) -> MessageManualLayoutProviderProtocol
     func createMenuPresenter(forModel model: Model) -> ChatItemMenuPresenterProtocol?
+    func contentAlignment(forModel model: Model) -> MessageContentAlignment
 }
 
 public extension MessageContentFactoryProtocol {
@@ -48,6 +54,7 @@ public final class AnyMessageContentFactory<Model>: MessageContentFactoryProtoco
     private let _createContentPresenter: (Model) -> MessageContentPresenterProtocol
     private let _createLayoutProvider: (Model) -> MessageManualLayoutProviderProtocol
     private let _createMenuPresenter: (Model) -> ChatItemMenuPresenterProtocol?
+    private let _contentAlignment: (Model) -> MessageContentAlignment
 
     public init<U: MessageContentFactoryProtocol>(_ base: U) where U.Model == Model {
         self.identifier = base.identifier
@@ -56,6 +63,7 @@ public final class AnyMessageContentFactory<Model>: MessageContentFactoryProtoco
         self._createContentPresenter = base.createContentPresenter
         self._createLayoutProvider = base.createLayoutProvider
         self._createMenuPresenter = base.createMenuPresenter
+        self._contentAlignment = base.contentAlignment
     }
 
     public let identifier: String
@@ -78,5 +86,9 @@ public final class AnyMessageContentFactory<Model>: MessageContentFactoryProtoco
 
     public func createMenuPresenter(forModel model: Model) -> ChatItemMenuPresenterProtocol? {
         return self._createMenuPresenter(model)
+    }
+
+    public func contentAlignment(forModel model: Model) -> MessageContentAlignment {
+        return self._contentAlignment(model)
     }
 }

--- a/ChattoAdditions/Source/Chat Items/CompoundMessage/Content/MessageManualLayoutProvider.swift
+++ b/ChattoAdditions/Source/Chat Items/CompoundMessage/Content/MessageManualLayoutProvider.swift
@@ -28,10 +28,6 @@ public protocol MessageManualLayoutProviderProtocol: HashableRepresentible {
     func sizeThatFits(size: CGSize, safeAreaInsets: UIEdgeInsets) -> CGSize
 }
 
-public extension MessageManualLayoutProviderProtocol {
-    var ignoreContentInsets: Bool { return false }
-}
-
 // MARK: - Text
 
 public struct TextMessageLayoutProvider: Hashable, MessageManualLayoutProviderProtocol {
@@ -47,6 +43,8 @@ public struct TextMessageLayoutProvider: Hashable, MessageManualLayoutProviderPr
         self.textInsets = textInsets
         self.numberOfLines = numberOfLines
     }
+
+    public let ignoreContentInsets: Bool = false
 
     public func sizeThatFits(size: CGSize, safeAreaInsets: UIEdgeInsets) -> CGSize {
         var sizeWithInset = size
@@ -81,6 +79,8 @@ public struct ImageMessageLayoutProvider: Hashable, MessageManualLayoutProviderP
     public init(imageSize: CGSize) {
         self.imageSize = imageSize
     }
+
+    public let ignoreContentInsets: Bool = false
 
     public func sizeThatFits(size: CGSize, safeAreaInsets _: UIEdgeInsets) -> CGSize {
         let ratio = self.imageSize.width / self.imageSize.height

--- a/ChattoAdditions/Source/Chat Items/CompoundMessage/Content/MessageManualLayoutProvider.swift
+++ b/ChattoAdditions/Source/Chat Items/CompoundMessage/Content/MessageManualLayoutProvider.swift
@@ -24,7 +24,12 @@
 import UIKit
 
 public protocol MessageManualLayoutProviderProtocol: HashableRepresentible {
+    var ignoreContentInsets: Bool { get }
     func sizeThatFits(size: CGSize, safeAreaInsets: UIEdgeInsets) -> CGSize
+}
+
+public extension MessageManualLayoutProviderProtocol {
+    var ignoreContentInsets: Bool { return false }
 }
 
 // MARK: - Text

--- a/ChattoAdditions/Source/Chat Items/CompoundMessage/Views/CompoundBubbleLayout.swift
+++ b/ChattoAdditions/Source/Chat Items/CompoundMessage/Views/CompoundBubbleLayout.swift
@@ -29,24 +29,39 @@ public struct CompoundBubbleLayout {
 
 public struct CompoundBubbleLayoutProvider {
 
+    public struct Dimensions: Hashable {
+        public let spacing: CGFloat
+        public let contentInsets: UIEdgeInsets
+
+        public init(spacing: CGFloat,
+                    contentInsets: UIEdgeInsets) {
+            self.spacing = spacing
+            self.contentInsets = contentInsets
+        }
+    }
+
     public struct Configuration: Hashable {
 
         fileprivate let layoutProviders: [MessageManualLayoutProviderProtocol]
         fileprivate let tailWidth: CGFloat
         fileprivate let isIncoming: Bool
+        fileprivate let dimensions: Dimensions
 
         public init(layoutProviders: [MessageManualLayoutProviderProtocol],
                     tailWidth: CGFloat,
-                    isIncoming: Bool) {
+                    isIncoming: Bool,
+                    dimensions: Dimensions) {
             self.layoutProviders = layoutProviders
             self.tailWidth = tailWidth
             self.isIncoming = isIncoming
+            self.dimensions = dimensions
         }
 
         public func hash(into hasher: inout Hasher) {
             hasher.combine(self.layoutProviders.map { $0.asHashable })
             hasher.combine(self.tailWidth)
             hasher.combine(self.isIncoming)
+            hasher.combine(self.dimensions)
         }
 
         public static func == (lhs: CompoundBubbleLayoutProvider.Configuration,
@@ -54,6 +69,7 @@ public struct CompoundBubbleLayoutProvider {
             return lhs.layoutProviders.map { $0.asHashable } == rhs.layoutProviders.map { $0.asHashable }
                 && lhs.tailWidth == rhs.tailWidth
                 && lhs.isIncoming == rhs.isIncoming
+                && lhs.dimensions == rhs.dimensions
         }
     }
 
@@ -73,25 +89,59 @@ public struct CompoundBubbleLayoutProvider {
         return layout
     }
 
+    private typealias RectWithLayoutProvider = (frame: CGRect, provider: MessageManualLayoutProviderProtocol)
+
     private func makeLayout(forMaxWidth width: CGFloat) -> CompoundBubbleLayout {
-        var subviewsFrames: [CGRect] = []
-        subviewsFrames.reserveCapacity(self.configuration.layoutProviders.count)
-        var maxY: CGFloat = 0
+        var subviewsFramesWithProviders: [RectWithLayoutProvider] = []
+        subviewsFramesWithProviders.reserveCapacity(self.configuration.layoutProviders.count)
+        let contentInsets = self.configuration.dimensions.contentInsets
+
         var resultWidth: CGFloat = 0
-        let sizeToFit = CGSize(width: width,
-                               height: .greatestFiniteMagnitude)
+        let fullWidthFittingSize = CGSize(width: width, height: .greatestFiniteMagnitude)
+        let fittingSizeWithInsets = fullWidthFittingSize.bma_insetBy(dx: contentInsets.bma_horziontalInset, dy: 0)
         let safeAreaInsets = self.safeAreaInsets()
-        for layoutProvider in self.configuration.layoutProviders {
-            let size = layoutProvider.sizeThatFits(size: sizeToFit, safeAreaInsets: safeAreaInsets)
-            let viewWidth = max(size.width, resultWidth)
-            resultWidth = min(viewWidth, width)
-            let frame = CGRect(x: 0, y: maxY, width: viewWidth, height: size.height)
-            subviewsFrames.append(frame)
+
+        let shouldAddTopInset = self.configuration.layoutProviders.first?.ignoreContentInsets == false
+        let shouldAddBottomInset = self.configuration.layoutProviders.last?.ignoreContentInsets == false
+
+        var maxY: CGFloat = shouldAddTopInset ? contentInsets.top : 0
+        for (i, layoutProvider) in self.configuration.layoutProviders.enumerated() {
+            let frame: CGRect
+            if layoutProvider.ignoreContentInsets {
+                let size = layoutProvider.sizeThatFits(size: fullWidthFittingSize, safeAreaInsets: safeAreaInsets)
+                let viewWidth = max(size.width, resultWidth)
+                resultWidth = min(viewWidth, width)
+                frame = CGRect(x: 0, y: maxY, width: viewWidth, height: size.height)
+            } else {
+                let size = layoutProvider.sizeThatFits(size: fittingSizeWithInsets, safeAreaInsets: safeAreaInsets)
+                let viewWidth = max(size.width, resultWidth)
+                resultWidth = min(viewWidth + contentInsets.bma_horziontalInset, width)
+                frame = CGRect(x: contentInsets.left, y: maxY, width: viewWidth, height: size.height)
+            }
+            subviewsFramesWithProviders.append((frame, layoutProvider))
             maxY = frame.maxY
+            if i != self.configuration.layoutProviders.count - 1 {
+                maxY += self.configuration.dimensions.spacing
+            }
         }
+
+        subviewsFramesWithProviders = subviewsFramesWithProviders.map({ frameWithProvider in
+            var newFrame = frameWithProvider.frame
+            if frameWithProvider.provider.ignoreContentInsets {
+                newFrame.size.width = resultWidth
+            } else {
+                newFrame.size.width = resultWidth - contentInsets.bma_horziontalInset
+            }
+            return (newFrame, frameWithProvider.provider)
+        })
+
+        if shouldAddBottomInset {
+            maxY += contentInsets.bottom
+        }
+
         return CompoundBubbleLayout(
             size: CGSize(width: resultWidth, height: maxY).bma_round(),
-            subviewsFrames: subviewsFrames,
+            subviewsFrames: subviewsFramesWithProviders.map({ $0.frame }),
             safeAreaInsets: safeAreaInsets
         )
     }

--- a/ChattoAdditions/Source/Chat Items/CompoundMessage/Views/CompoundBubbleLayout.swift
+++ b/ChattoAdditions/Source/Chat Items/CompoundMessage/Views/CompoundBubbleLayout.swift
@@ -102,9 +102,7 @@ public struct CompoundBubbleLayoutProvider {
                                        right: safeAreaInsets.right + contentInsets.right)
 
         var resultWidth: CGFloat = 0
-        let fullWidthFittingSizeWithSafeInsets = CGSize(width: width - safeAreaInsets.bma_horziontalInset, height: .greatestFiniteMagnitude)
-        let fittingSizeWithInsets = fullWidthFittingSizeWithSafeInsets.bma_insetBy(dx: totalInsets.bma_horziontalInset, dy: 0)
-
+        let fittingSizeWithInsets = CGSize(width: width - contentInsets.bma_horziontalInset, height: .greatestFiniteMagnitude)
         let shouldAddTopInset = self.configuration.layoutProviders.first?.ignoreContentInsets == false
         let shouldAddBottomInset = self.configuration.layoutProviders.last?.ignoreContentInsets == false
 
@@ -112,10 +110,10 @@ public struct CompoundBubbleLayoutProvider {
         for (i, layoutProvider) in self.configuration.layoutProviders.enumerated() {
             let frame: CGRect
             if layoutProvider.ignoreContentInsets {
-                let size = layoutProvider.sizeThatFits(size: fullWidthFittingSizeWithSafeInsets, safeAreaInsets: safeAreaInsets)
+                let size = layoutProvider.sizeThatFits(size: CGSize(width: width, height: .greatestFiniteMagnitude), safeAreaInsets: safeAreaInsets)
                 let viewWidth = max(size.width, resultWidth)
                 resultWidth = min(viewWidth, width)
-                frame = CGRect(x: safeAreaInsets.left, y: maxY, width: viewWidth, height: size.height)
+                frame = CGRect(x: 0, y: maxY, width: viewWidth, height: size.height)
             } else {
                 let size = layoutProvider.sizeThatFits(size: fittingSizeWithInsets, safeAreaInsets: safeAreaInsets)
                 let viewWidth = max(size.width, resultWidth)
@@ -132,7 +130,7 @@ public struct CompoundBubbleLayoutProvider {
         subviewsFramesWithProviders = subviewsFramesWithProviders.map({ frameWithProvider in
             var newFrame = frameWithProvider.frame
             if frameWithProvider.provider.ignoreContentInsets {
-                newFrame.size.width = resultWidth - safeAreaInsets.bma_horziontalInset
+                newFrame.size.width = resultWidth
             } else {
                 newFrame.size.width = resultWidth - totalInsets.bma_horziontalInset
             }

--- a/ChattoAdditions/Source/Chat Items/CompoundMessage/Views/CompoundBubbleLayout.swift
+++ b/ChattoAdditions/Source/Chat Items/CompoundMessage/Views/CompoundBubbleLayout.swift
@@ -117,7 +117,7 @@ public struct CompoundBubbleLayoutProvider {
                 resultWidth = min(viewWidth, width)
                 frame = CGRect(x: safeAreaInsets.left, y: maxY, width: viewWidth, height: size.height)
             } else {
-                let size = layoutProvider.sizeThatFits(size: fittingSizeWithInsets, safeAreaInsets: totalInsets)
+                let size = layoutProvider.sizeThatFits(size: fittingSizeWithInsets, safeAreaInsets: safeAreaInsets)
                 let viewWidth = max(size.width, resultWidth)
                 resultWidth = min(viewWidth + totalInsets.bma_horziontalInset, width)
                 frame = CGRect(x: totalInsets.left, y: maxY, width: viewWidth, height: size.height)

--- a/ChattoApp/ChattoApp/Source/Chat View Controllers/DemoChatViewController.swift
+++ b/ChattoApp/ChattoApp/Source/Chat View Controllers/DemoChatViewController.swift
@@ -96,6 +96,7 @@ class DemoChatViewController: BaseChatViewController {
                 .init(DemoImageMessageContentFactory()),
                 .init(DemoDateMessageContentFactory())
             ],
+            compoundCellDimensions: .defaultDimensions,
             baseCellStyle: BaseMessageCollectionViewCellAvatarStyle()
         )
 
@@ -150,5 +151,11 @@ extension DemoChatViewController: MessagesSelectorDelegate {
 
     func messagesSelector(_ messagesSelector: MessagesSelectorProtocol, didDeselectMessage: MessageModelProtocol) {
         self.enqueueModelUpdate(updateType: .normal)
+    }
+}
+
+extension CompoundBubbleLayoutProvider.Dimensions {
+    static var defaultDimensions: CompoundBubbleLayoutProvider.Dimensions {
+        return .init(spacing: 8, contentInsets: UIEdgeInsets(top: 8, left: 8, bottom: 8, right: 8))
     }
 }


### PR DESCRIPTION
- Now insets and spacing for compound bubble components are defined on the bubble level, as opposed to the previous method when each bubble could define it's own insets.
- Added new struct for providing new configuration CompoundBubbleLayoutProvider.Dimensions
- Make bubble components fill all bubble width after determining it's size (by the widest component)
- Additional option for MessageManualLayoutProviderProtocol to ignore content insets within the bubble (so component fill all available width minus safe insets)