### PR TITLE
Access UIPasteboard only during copy action

### DIFF
--- a/ChattoAdditions/Source/Chat Items/TextMessages/TextMessageMenuItemPresenter.swift
+++ b/ChattoAdditions/Source/Chat Items/TextMessages/TextMessageMenuItemPresenter.swift
@@ -31,15 +31,16 @@ public protocol TextMessageMenuItemPresenterProtocol {
 }
 
 public final class TextMessageMenuItemPresenter: TextMessageMenuItemPresenterProtocol {
+    public typealias PasteboardProvider = () -> UIPasteboard
 
     // MARK: - Private properties
 
-    private let pasteboard: UIPasteboard
+    private let pasteboardProvider: PasteboardProvider
 
     // MARK: - Instantiation
 
-    public init(pasteboard: UIPasteboard = .general) {
-        self.pasteboard = pasteboard
+    public init(pasteboard: @escaping @autoclosure PasteboardProvider = .general) {
+        self.pasteboardProvider = pasteboard
     }
 
     // MARK: - TextMessageMenuItemPresenterProtocol
@@ -57,7 +58,7 @@ public final class TextMessageMenuItemPresenter: TextMessageMenuItemPresenterPro
             assertionFailure("Unexpected action")
             return
         }
-        self.pasteboard.string = text
+        self.pasteboardProvider().string = text
     }
 }
 


### PR DESCRIPTION
#616 

This change doesn't resolve issue completely, because it seems to be a bug in iOS 13 Simulator (no such cases found in production build crash logs). Even if we move all UIPasteboard usages to background thread, we still may get freeze like this:

<img width="357" alt="Screenshot 2019-10-14 at 18 03 54" src="https://user-images.githubusercontent.com/3374306/66769661-90f15a00-eead-11e9-8885-81f9a655b6fd.png">

However, with this change, the issue will be reproducible only when you try to perform copy action, which makes it less annoying. 