### PR TITLE
Open avatar customization

### DIFF
--- a/ChattoAdditions/Source/Chat Items/BaseMessage/Views/BaseMessageCollectionViewCell.swift
+++ b/ChattoAdditions/Source/Chat Items/BaseMessage/Views/BaseMessageCollectionViewCell.swift
@@ -247,6 +247,7 @@ open class BaseMessageCollectionViewCell<BubbleViewType>: UICollectionViewCell, 
     }
 
     private func observeAvatar() {
+        guard self.viewContext != .sizing else { return }
         guard let viewModel = self.messageViewModel else { return }
         self.avatarView.isHidden = !viewModel.decorationAttributes.isShowingAvatar
         self.avatarView.image = viewModel.avatarImage.value

--- a/ChattoAdditions/Source/Chat Items/BaseMessage/Views/BaseMessageCollectionViewCell.swift
+++ b/ChattoAdditions/Source/Chat Items/BaseMessage/Views/BaseMessageCollectionViewCell.swift
@@ -98,7 +98,9 @@ open class BaseMessageCollectionViewCell<BubbleViewType>: UICollectionViewCell, 
 
     open var messageViewModel: MessageViewModelProtocol! {
         didSet {
+            oldValue?.avatarImage.removeObserver(self)
             self.updateViews()
+            self.observeAvatar()
         }
     }
 
@@ -235,7 +237,6 @@ open class BaseMessageCollectionViewCell<BubbleViewType>: UICollectionViewCell, 
             self.failedButton.alpha = 0
         }
         self.accessoryTimestampView.attributedText = style.attributedStringForDate(viewModel.date)
-        self.updateAvatarView(from: viewModel, with: style)
         self.updateSelectionIndicator(with: style)
 
         self.contentView.isUserInteractionEnabled = !viewModel.decorationAttributes.isShowingSelectionIndicator
@@ -245,13 +246,13 @@ open class BaseMessageCollectionViewCell<BubbleViewType>: UICollectionViewCell, 
         self.layoutIfNeeded()
     }
 
-    private func updateAvatarView(from viewModel: MessageViewModelProtocol,
-                                  with style: BaseMessageCollectionViewCellStyleProtocol) {
+    private func observeAvatar() {
+        guard let viewModel = self.messageViewModel else { return }
         self.avatarView.isHidden = !viewModel.decorationAttributes.isShowingAvatar
-
-        let avatarImageSize = style.avatarSize(viewModel: viewModel)
-        if avatarImageSize != .zero {
-            self.avatarView.image = viewModel.avatarImage.value
+        self.avatarView.image = viewModel.avatarImage.value
+        viewModel.avatarImage.observe(self) { [weak self] _, new in
+            guard let self = self else { return }
+            self.avatarView.image = new
         }
     }
 

--- a/ChattoAdditions/Source/Chat Items/BaseMessage/Views/BaseMessageCollectionViewCell.swift
+++ b/ChattoAdditions/Source/Chat Items/BaseMessage/Views/BaseMessageCollectionViewCell.swift
@@ -130,7 +130,7 @@ open class BaseMessageCollectionViewCell<BubbleViewType>: UICollectionViewCell, 
     }
 
     public private(set) var avatarView: UIImageView!
-    func createAvatarView() -> UIImageView! {
+    open func createAvatarView() -> UIImageView! {
         let avatarImageView = UIImageView(frame: CGRect.zero)
         avatarImageView.isUserInteractionEnabled = true
         return avatarImageView

--- a/ChattoAdditions/Source/Chat Items/BaseMessage/Views/BaseMessageCollectionViewCellDefaultStyle.swift
+++ b/ChattoAdditions/Source/Chat Items/BaseMessage/Views/BaseMessageCollectionViewCellDefaultStyle.swift
@@ -105,10 +105,11 @@ open class BaseMessageCollectionViewCellDefaultStyle: BaseMessageCollectionViewC
     let failedIconImages: FailedIconImages
     let layoutConstants: BaseMessageCollectionViewCellLayoutConstants
     let dateTextStyle: DateTextStyle
-    let avatarStyle: AvatarStyle
+    let incomingAvatarStyle: AvatarStyle
+    let outgoingAvatarStyle: AvatarStyle
     let selectionIndicatorStyle: SelectionIndicatorStyle
 
-    public init(
+    public convenience init(
         colors: Colors = BaseMessageCollectionViewCellDefaultStyle.createDefaultColors(),
         bubbleBorderImages: BubbleBorderImages? = BaseMessageCollectionViewCellDefaultStyle.createDefaultBubbleBorderImages(),
         failedIconImages: FailedIconImages = BaseMessageCollectionViewCellDefaultStyle.createDefaultFailedIconImages(),
@@ -116,18 +117,39 @@ open class BaseMessageCollectionViewCellDefaultStyle: BaseMessageCollectionViewC
         dateTextStyle: DateTextStyle = BaseMessageCollectionViewCellDefaultStyle.createDefaultDateTextStyle(),
         avatarStyle: AvatarStyle = AvatarStyle(),
         selectionIndicatorStyle: SelectionIndicatorStyle = BaseMessageCollectionViewCellDefaultStyle.createDefaultSelectionIndicatorStyle()) {
-            self.colors = colors
-            self.bubbleBorderImages = bubbleBorderImages
-            self.failedIconImages = failedIconImages
-            self.layoutConstants = layoutConstants
-            self.dateTextStyle = dateTextStyle
-            self.avatarStyle = avatarStyle
-            self.selectionIndicatorStyle = selectionIndicatorStyle
+        self.init(colors: colors,
+                  bubbleBorderImages: bubbleBorderImages,
+                  failedIconImages: failedIconImages,
+                  layoutConstants: layoutConstants,
+                  dateTextStyle: dateTextStyle,
+                  incomingAvatarStyle: avatarStyle,
+                  outgoingAvatarStyle: avatarStyle,
+                  selectionIndicatorStyle: selectionIndicatorStyle)
+    }
 
-            self.dateStringAttributes = [
-                NSAttributedString.Key.font: self.dateTextStyle.font(),
-                NSAttributedString.Key.foregroundColor: self.dateTextStyle.color()
-            ]
+    public init(
+        colors: Colors = BaseMessageCollectionViewCellDefaultStyle.createDefaultColors(),
+        bubbleBorderImages: BubbleBorderImages? = BaseMessageCollectionViewCellDefaultStyle.createDefaultBubbleBorderImages(),
+        failedIconImages: FailedIconImages = BaseMessageCollectionViewCellDefaultStyle.createDefaultFailedIconImages(),
+        layoutConstants: BaseMessageCollectionViewCellLayoutConstants = BaseMessageCollectionViewCellDefaultStyle.createDefaultLayoutConstants(),
+        dateTextStyle: DateTextStyle = BaseMessageCollectionViewCellDefaultStyle.createDefaultDateTextStyle(),
+        incomingAvatarStyle: AvatarStyle = AvatarStyle(),
+        outgoingAvatarStyle: AvatarStyle = AvatarStyle(),
+        selectionIndicatorStyle: SelectionIndicatorStyle = BaseMessageCollectionViewCellDefaultStyle.createDefaultSelectionIndicatorStyle()
+    ) {
+        self.colors = colors
+        self.bubbleBorderImages = bubbleBorderImages
+        self.failedIconImages = failedIconImages
+        self.layoutConstants = layoutConstants
+        self.dateTextStyle = dateTextStyle
+        self.incomingAvatarStyle = incomingAvatarStyle
+        self.outgoingAvatarStyle = outgoingAvatarStyle
+        self.selectionIndicatorStyle = selectionIndicatorStyle
+
+        self.dateStringAttributes = [
+            NSAttributedString.Key.font: self.dateTextStyle.font(),
+            NSAttributedString.Key.foregroundColor: self.dateTextStyle.color()
+        ]
     }
 
     public lazy var baseColorIncoming: UIColor = self.colors.incoming()
@@ -161,11 +183,11 @@ open class BaseMessageCollectionViewCellDefaultStyle: BaseMessageCollectionViewC
     }
 
     open func avatarSize(viewModel: MessageViewModelProtocol) -> CGSize {
-        return self.avatarStyle.size
+        return self.avatarStyle(for: viewModel).size
     }
 
     open func avatarVerticalAlignment(viewModel: MessageViewModelProtocol) -> VerticalAlignment {
-        return self.avatarStyle.alignment
+        return self.avatarStyle(for: viewModel).alignment
     }
 
     public var selectionIndicatorMargins: UIEdgeInsets {
@@ -178,6 +200,10 @@ open class BaseMessageCollectionViewCellDefaultStyle: BaseMessageCollectionViewC
 
     open func layoutConstants(viewModel: MessageViewModelProtocol) -> BaseMessageCollectionViewCellLayoutConstants {
         return self.layoutConstants
+    }
+
+    private func avatarStyle(for viewModel: MessageViewModelProtocol) -> AvatarStyle {
+        return viewModel.isIncoming ? self.incomingAvatarStyle : self.outgoingAvatarStyle
     }
 }
 

--- a/ChattoAdditions/Source/Chat Items/CompoundMessage/CompoundMessagePresenter.swift
+++ b/ChattoAdditions/Source/Chat Items/CompoundMessage/CompoundMessagePresenter.swift
@@ -40,6 +40,7 @@ open class CompoundMessagePresenter<ViewModelBuilderT, InteractionHandlerT>
     private let compoundCellDimensions: CompoundBubbleLayoutProvider.Dimensions
     private let cache: Cache<CompoundBubbleLayoutProvider.Configuration, CompoundBubbleLayoutProvider>
     private let accessibilityIdentifier: String?
+    private let cellClass: CompoundMessageCollectionViewCell.Type
 
     private let initialContentFactories: [AnyMessageContentFactory<ModelT>]
     private var contentFactories: [AnyMessageContentFactory<ModelT>]!
@@ -56,13 +57,15 @@ open class CompoundMessagePresenter<ViewModelBuilderT, InteractionHandlerT>
         compoundCellStyle: CompoundBubbleViewStyleProtocol,
         compoundCellDimensions: CompoundBubbleLayoutProvider.Dimensions,
         cache: Cache<CompoundBubbleLayoutProvider.Configuration, CompoundBubbleLayoutProvider>,
-        accessibilityIdentifier: String?
+        accessibilityIdentifier: String?,
+        cellClass: CompoundMessageCollectionViewCell.Type = CompoundMessageCollectionViewCell.self
     ) {
         self.compoundCellStyle = compoundCellStyle
         self.compoundCellDimensions = compoundCellDimensions
         self.initialContentFactories = contentFactories
         self.cache = cache
         self.accessibilityIdentifier = accessibilityIdentifier
+        self.cellClass = cellClass
         super.init(
             messageModel: messageModel,
             viewModelBuilder: viewModelBuilder,
@@ -129,7 +132,7 @@ open class CompoundMessagePresenter<ViewModelBuilderT, InteractionHandlerT>
 
     open override func dequeueCell(collectionView: UICollectionView, indexPath: IndexPath) -> UICollectionViewCell {
         let cellReuseIdentifier = self.compoundCellReuseId
-        collectionView.register(CompoundMessageCollectionViewCell.self, forCellWithReuseIdentifier: cellReuseIdentifier)
+        collectionView.register(self.cellClass, forCellWithReuseIdentifier: cellReuseIdentifier)
         return collectionView.dequeueReusableCell(withReuseIdentifier: cellReuseIdentifier, for: indexPath)
     }
 

--- a/ChattoAdditions/Source/Chat Items/CompoundMessage/Views/CompoundMessageCollectionViewCell.swift
+++ b/ChattoAdditions/Source/Chat Items/CompoundMessage/Views/CompoundMessageCollectionViewCell.swift
@@ -22,11 +22,11 @@
 // THE SOFTWARE.
 
 @available(iOS 11, *)
-public final class CompoundMessageCollectionViewCell: BaseMessageCollectionViewCell<CompoundBubbleView> {
+open class CompoundMessageCollectionViewCell: BaseMessageCollectionViewCell<CompoundBubbleView> {
 
-    public override func createBubbleView() -> CompoundBubbleView! {
+    open override func createBubbleView() -> CompoundBubbleView! {
         return CompoundBubbleView()
     }
 
-    public var viewReferences: [ViewReference]?
+    public final var viewReferences: [ViewReference]?
 }

--- a/ChattoAdditions/Source/Common/Observable.swift
+++ b/ChattoAdditions/Source/Common/Observable.swift
@@ -46,6 +46,10 @@ public class Observable<T> {
         self.cleanDeadObservers()
     }
 
+    public func removeObserver(_ observer: AnyObject) {
+        self.observers.removeAll { $0.owner === observer }
+    }
+
     private func cleanDeadObservers() {
         self.observers = self.observers.filter { $0.owner != nil }
     }

--- a/ChattoApp/ChattoApp.xcodeproj/project.pbxproj
+++ b/ChattoApp/ChattoApp.xcodeproj/project.pbxproj
@@ -16,6 +16,7 @@
 		268CD57A22034A9900DEE2C2 /* DemoImageMessageContentFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 268CD57922034A9900DEE2C2 /* DemoImageMessageContentFactory.swift */; };
 		268CD57E220377D500DEE2C2 /* DemoDateMessageContentFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 268CD57D220377D500DEE2C2 /* DemoDateMessageContentFactory.swift */; };
 		26D6D524220CAAE2006232B4 /* UpdateItemTypeViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26D6D523220CAAE2006232B4 /* UpdateItemTypeViewController.swift */; };
+		26FAADC423747B1300F62D01 /* AsyncAvatarLoadingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26FAADC323747B1300F62D01 /* AsyncAvatarLoadingViewController.swift */; };
 		5587302E1FCD7EE5005BC2EC /* MessagesSelectionChatViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5587302D1FCD7EE5005BC2EC /* MessagesSelectionChatViewController.swift */; };
 		558730341FCD8891005BC2EC /* AddRandomMessageChatViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 558730331FCD8891005BC2EC /* AddRandomMessageChatViewController.swift */; };
 		55A77B4A1FCC5EE70040C77E /* MessagesSelectorProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55A77B491FCC5EE70040C77E /* MessagesSelectorProtocol.swift */; };
@@ -84,6 +85,7 @@
 		268CD57922034A9900DEE2C2 /* DemoImageMessageContentFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DemoImageMessageContentFactory.swift; sourceTree = "<group>"; };
 		268CD57D220377D500DEE2C2 /* DemoDateMessageContentFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DemoDateMessageContentFactory.swift; sourceTree = "<group>"; };
 		26D6D523220CAAE2006232B4 /* UpdateItemTypeViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdateItemTypeViewController.swift; sourceTree = "<group>"; };
+		26FAADC323747B1300F62D01 /* AsyncAvatarLoadingViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AsyncAvatarLoadingViewController.swift; sourceTree = "<group>"; };
 		2CCB5DAFC70B636492325895 /* Pods-ChattoApp.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ChattoApp.debug.xcconfig"; path = "Pods/Target Support Files/Pods-ChattoApp/Pods-ChattoApp.debug.xcconfig"; sourceTree = "<group>"; };
 		5587302D1FCD7EE5005BC2EC /* MessagesSelectionChatViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessagesSelectionChatViewController.swift; sourceTree = "<group>"; };
 		558730331FCD8891005BC2EC /* AddRandomMessageChatViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddRandomMessageChatViewController.swift; sourceTree = "<group>"; };
@@ -201,6 +203,7 @@
 				C3F91DA81C75EF9E00D461D2 /* DemoChatViewController.swift */,
 				26D6D523220CAAE2006232B4 /* UpdateItemTypeViewController.swift */,
 				EAE6345622EB0CAD0053E21A /* TestItemsReloadingViewController.swift */,
+				26FAADC323747B1300F62D01 /* AsyncAvatarLoadingViewController.swift */,
 			);
 			path = "Chat View Controllers";
 			sourceTree = "<group>";
@@ -504,6 +507,7 @@
 				C3F91DC51C75EF9E00D461D2 /* DemoTextMessageModel.swift in Sources */,
 				55EE230821BFFD6600D50A1C /* ScrollToBottomButtonChatViewController.swift in Sources */,
 				5587302E1FCD7EE5005BC2EC /* MessagesSelectionChatViewController.swift in Sources */,
+				26FAADC423747B1300F62D01 /* AsyncAvatarLoadingViewController.swift in Sources */,
 				268CD578220336EB00DEE2C2 /* DemoTextMessageContentFactory.swift in Sources */,
 				C3F91DCC1C75EFE300D461D2 /* SendingStatusCollectionViewCell.swift in Sources */,
 				C3F91DB71C75EF9E00D461D2 /* DemoChatItemsDecorator.swift in Sources */,

--- a/ChattoApp/ChattoApp/Source/Chat Items/Text Messages/DemoTextMessageViewModel.swift
+++ b/ChattoApp/ChattoApp/Source/Chat Items/Text Messages/DemoTextMessageViewModel.swift
@@ -37,14 +37,23 @@ public class DemoTextMessageViewModel: TextMessageViewModel<DemoTextMessageModel
 }
 
 public class DemoTextMessageViewModelBuilder: ViewModelBuilderProtocol {
-    public init() {}
+
+    typealias ObservableImageProvider = (DemoTextMessageModel) -> Observable<UIImage?>
+
+    private static let defaultObservableImageProvider: ObservableImageProvider = { _ in Observable(UIImage(named: "userAvatar")) }
+
+    private let imageProvider: ObservableImageProvider
+
+    init(imageProvider: @escaping ObservableImageProvider = DemoTextMessageViewModelBuilder.defaultObservableImageProvider) {
+        self.imageProvider = imageProvider
+    }
 
     let messageViewModelBuilder = MessageViewModelDefaultBuilder()
 
     public func createViewModel(_ textMessage: DemoTextMessageModel) -> DemoTextMessageViewModel {
         let messageViewModel = self.messageViewModelBuilder.createMessageViewModel(textMessage)
         let textMessageViewModel = DemoTextMessageViewModel(textMessage: textMessage, messageViewModel: messageViewModel)
-        textMessageViewModel.avatarImage.value = UIImage(named: "userAvatar")
+        textMessageViewModel.avatarImage = self.imageProvider(textMessage)
         return textMessageViewModel
     }
 

--- a/ChattoApp/ChattoApp/Source/Chat View Controllers/AsyncAvatarLoadingViewController.swift
+++ b/ChattoApp/ChattoApp/Source/Chat View Controllers/AsyncAvatarLoadingViewController.swift
@@ -1,0 +1,68 @@
+//
+// The MIT License (MIT)
+//
+// Copyright (c) 2015-present Badoo Trading Limited.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import Chatto
+import ChattoAdditions
+
+final class AsyncAvatarLoadingViewController: DemoChatViewController {
+
+    private var randomGenerator = SystemRandomNumberGenerator()
+
+    override func viewDidLoad() {
+        let messages: [ChatItemProtocol] = Array(0 ..< 10_000).map { index in
+            let uid = String(index)
+            let text = String(index)
+            return DemoChatMessageFactory.makeTextMessage(uid, text: text, isIncoming: index % 2 == 0)
+        }
+
+        self.dataSource = DemoChatDataSource(messages: messages, pageSize: 50)
+        super.viewDidLoad()
+    }
+
+    override func createTextMessageViewModelBuilder() -> DemoTextMessageViewModelBuilder {
+        DemoTextMessageViewModelBuilder { message in
+            let observable: Observable<UIImage?> = .init(nil)
+            let imageSize = CGSize(width: 40, height: 40)
+            let randomTime = Int(self.randomGenerator.next() % 10 + 1)
+            DispatchQueue.main.asyncAfter(deadline: .now() + .seconds(randomTime)) {
+                observable.value = UIImage.makeImage(ofSize: imageSize, text: message.uid)
+            }
+            return observable
+        }
+    }
+}
+
+private extension UIImage {
+    static func makeImage(ofSize size: CGSize, text: String) -> UIImage {
+        let frame = CGRect(origin: .zero, size: size)
+        let label = UILabel(frame: frame)
+        label.text = text
+        label.backgroundColor = .white
+        label.textColor = .black
+        label.font = .systemFont(ofSize: 17)
+        UIGraphicsBeginImageContext(size)
+        let currentContext = UIGraphicsGetCurrentContext()!
+        label.layer.render(in: currentContext)
+        return UIGraphicsGetImageFromCurrentImageContext()!
+    }
+}

--- a/ChattoApp/ChattoApp/Source/Chat View Controllers/DemoChatViewController.swift
+++ b/ChattoApp/ChattoApp/Source/Chat View Controllers/DemoChatViewController.swift
@@ -76,7 +76,7 @@ class DemoChatViewController: BaseChatViewController {
     override func createPresenterBuilders() -> [ChatItemType: [ChatItemPresenterBuilderProtocol]] {
 
         let textMessagePresenter = TextMessagePresenterBuilder(
-            viewModelBuilder: DemoTextMessageViewModelBuilder(),
+            viewModelBuilder: self.createTextMessageViewModelBuilder(),
             interactionHandler: GenericMessageHandler(baseHandler: self.baseMessageHandler)
         )
         textMessagePresenter.baseMessageStyle = BaseMessageCollectionViewCellAvatarStyle()
@@ -107,6 +107,10 @@ class DemoChatViewController: BaseChatViewController {
             TimeSeparatorModel.chatItemType: [TimeSeparatorPresenterBuilder()],
             ChatItemType.compoundItemType: [compoundPresenterBuilder]
         ]
+    }
+
+    func createTextMessageViewModelBuilder() -> DemoTextMessageViewModelBuilder {
+        return DemoTextMessageViewModelBuilder()
     }
 
     func createChatInputItems() -> [ChatInputItemProtocol] {

--- a/ChattoApp/ChattoApp/Source/ChatExamplesViewController.swift
+++ b/ChattoApp/ChattoApp/Source/ChatExamplesViewController.swift
@@ -41,7 +41,8 @@ class ChatExamplesViewController: CellsViewController {
             self.makeScrollToBottomCellItem(),
             self.makeCompoundDemoViewController(),
             self.makeUpdateItemTypeViewController(),
-            self.makeTestItemsReloadingCellItem()
+            self.makeTestItemsReloadingCellItem(),
+            self.makeAsyncAvatarLoadingCellItem()
         ]
     }
 
@@ -121,6 +122,12 @@ class ChatExamplesViewController: CellsViewController {
     private func makeTestItemsReloadingCellItem() -> CellItem {
         return CellItem(title: "Test items reloading") { [unowned self] in
             self.navigationController?.pushViewController(TestItemsReloadingViewController(), animated: true)
+        }
+    }
+
+    private func makeAsyncAvatarLoadingCellItem() -> CellItem {
+        return CellItem(title: "Async avatar loading") { [unowned self] in
+            self.navigationController?.pushViewController(AsyncAvatarLoadingViewController(), animated: true)
         }
     }
 


### PR DESCRIPTION
- Fixed observing of avatarImage.
- Made `BaseMessageCollectionViewCell.createAvatarView` open 
- Added ability to set incoming & outgoing avatarStyles
- Made Cell class injectable in `CompoundMessagePresenter`
- Added demo screen with asynchronously loading avatars to ChattoApp