### PR TITLE
Enable module stability support

### DIFF
--- a/Chatto/Chatto.xcodeproj/project.pbxproj
+++ b/Chatto/Chatto.xcodeproj/project.pbxproj
@@ -440,7 +440,7 @@
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 3.0;
+				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
@@ -492,7 +492,7 @@
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
-				SWIFT_VERSION = 3.0;
+				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VALIDATE_PRODUCT = YES;
 				VERSIONING_SYSTEM = "apple-generic";
@@ -515,7 +515,6 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.badoo.Chatto;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
-				SWIFT_VERSION = 4.2;
 			};
 			name = Debug;
 		};
@@ -534,7 +533,6 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.badoo.Chatto;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
-				SWIFT_VERSION = 4.2;
 			};
 			name = Release;
 		};
@@ -547,7 +545,6 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.badoo.ChattoTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_SWIFT3_OBJC_INFERENCE = Default;
-				SWIFT_VERSION = 4.0;
 			};
 			name = Debug;
 		};
@@ -560,7 +557,6 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.badoo.ChattoTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_SWIFT3_OBJC_INFERENCE = Default;
-				SWIFT_VERSION = 4.0;
 			};
 			name = Release;
 		};

--- a/Chatto/Chatto.xcodeproj/project.pbxproj
+++ b/Chatto/Chatto.xcodeproj/project.pbxproj
@@ -451,6 +451,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				BUILD_LIBRARY_FOR_DISTRIBUTION = YES;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CLANG_CXX_LIBRARY = "libc++";
 				CLANG_ENABLE_MODULES = YES;

--- a/Chatto/Source/ChatController/BaseChatViewController+AccessoryViewRevealer.swift
+++ b/Chatto/Source/ChatController/BaseChatViewController+AccessoryViewRevealer.swift
@@ -26,7 +26,7 @@ import Foundation
 
 public extension BaseChatViewController { // Accessory view revealer
 
-    public final var accessoryViewRevealerIsEnabled: Bool {
+    final var accessoryViewRevealerIsEnabled: Bool {
         get {
             return self.accessoryViewRevealer.isEnabled
         } set {
@@ -34,7 +34,7 @@ public extension BaseChatViewController { // Accessory view revealer
         }
     }
 
-    public final var accessoryViewRevealerConfig: AccessoryViewRevealerConfig {
+    final var accessoryViewRevealerConfig: AccessoryViewRevealerConfig {
         get {
             return self.accessoryViewRevealer.config
         } set {

--- a/Chatto/Tests/ChatController/BaseChatViewControllerTests.swift
+++ b/Chatto/Tests/ChatController/BaseChatViewControllerTests.swift
@@ -214,7 +214,7 @@ class ChatViewControllerTests: XCTestCase {
         fakeDataSource.chatItems = createFakeChatItems(count: 2)
         controller.chatDataSource = fakeDataSource
         self.fakeDidAppearAndLayout(controller: controller)
-        notificationCenter.post(name: NSNotification.Name.UIKeyboardWillShow, object: self, userInfo: [UIKeyboardFrameEndUserInfoKey: NSValue(cgRect: CGRect(x: 0, y: 400, width: 400, height: 500))])
+        notificationCenter.post(name: UIResponder.keyboardWillShowNotification, object: self, userInfo: [UIResponder.keyboardFrameEndUserInfoKey: NSValue(cgRect: CGRect(x: 0, y: 400, width: 400, height: 500))])
         XCTAssertEqual(400, controller.view.convert(controller.chatInputView.bounds, from: controller.chatInputView).maxY)
     }
 
@@ -226,9 +226,9 @@ class ChatViewControllerTests: XCTestCase {
         fakeDataSource.chatItems = createFakeChatItems(count: 2)
         controller.chatDataSource = fakeDataSource
         self.fakeDidAppearAndLayout(controller: controller)
-        notificationCenter.post(name: NSNotification.Name.UIKeyboardWillShow, object: self, userInfo: [UIKeyboardFrameEndUserInfoKey: NSValue(cgRect: CGRect(x: 0, y: 400, width: 400, height: 500))])
-        notificationCenter.post(name: NSNotification.Name.UIKeyboardDidShow, object: self, userInfo: [UIKeyboardFrameEndUserInfoKey: NSValue(cgRect: CGRect(x: 0, y: 400, width: 400, height: 500))])
-        notificationCenter.post(name: NSNotification.Name.UIKeyboardWillHide, object: self, userInfo: [UIKeyboardFrameEndUserInfoKey: NSValue(cgRect: CGRect(x: 0, y: 400, width: 400, height: 500))])
+        notificationCenter.post(name: UIResponder.keyboardWillShowNotification, object: self, userInfo: [UIResponder.keyboardFrameEndUserInfoKey: NSValue(cgRect: CGRect(x: 0, y: 400, width: 400, height: 500))])
+        notificationCenter.post(name: UIResponder.keyboardDidShowNotification, object: self, userInfo: [UIResponder.keyboardFrameEndUserInfoKey: NSValue(cgRect: CGRect(x: 0, y: 400, width: 400, height: 500))])
+        notificationCenter.post(name: UIResponder.keyboardWillHideNotification, object: self, userInfo: [UIResponder.keyboardFrameEndUserInfoKey: NSValue(cgRect: CGRect(x: 0, y: 400, width: 400, height: 500))])
         XCTAssertEqual(900, controller.view.convert(controller.chatInputView.bounds, from: controller.chatInputView).maxY)
     }
 

--- a/ChattoAdditions/ChattoAdditions.xcodeproj/project.pbxproj
+++ b/ChattoAdditions/ChattoAdditions.xcodeproj/project.pbxproj
@@ -979,6 +979,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				BUILD_LIBRARY_FOR_DISTRIBUTION = YES;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CLANG_CXX_LIBRARY = "libc++";
 				CLANG_ENABLE_MODULES = YES;

--- a/ChattoAdditions/ChattoAdditions.xcodeproj/project.pbxproj
+++ b/ChattoAdditions/ChattoAdditions.xcodeproj/project.pbxproj
@@ -968,7 +968,7 @@
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 3.0;
+				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
@@ -1020,7 +1020,7 @@
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
-				SWIFT_VERSION = 3.0;
+				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VALIDATE_PRODUCT = YES;
 				VERSIONING_SYSTEM = "apple-generic";
@@ -1043,7 +1043,6 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.badoo.ChattoAdditions;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
-				SWIFT_VERSION = 4.2;
 			};
 			name = Debug;
 		};
@@ -1062,7 +1061,6 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.badoo.ChattoAdditions;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
-				SWIFT_VERSION = 4.2;
 			};
 			name = Release;
 		};
@@ -1074,7 +1072,6 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.badoo.ChattoAdditionsTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 4.2;
 			};
 			name = Debug;
 		};
@@ -1086,7 +1083,6 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.badoo.ChattoAdditionsTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 4.2;
 			};
 			name = Release;
 		};

--- a/ChattoAdditions/Source/Chat Items/BaseMessage/BaseMessageViewModel.swift
+++ b/ChattoAdditions/Source/Chat Items/BaseMessage/BaseMessageViewModel.swift
@@ -31,7 +31,7 @@ public enum MessageViewModelStatus {
 }
 
 public extension MessageStatus {
-    public func viewModelStatus() -> MessageViewModelStatus {
+    func viewModelStatus() -> MessageViewModelStatus {
         switch self {
         case .success:
             return MessageViewModelStatus.success

--- a/ChattoAdditions/Source/Chat Items/BaseMessage/Views/BaseMessageCollectionViewCellDefaultStyle.swift
+++ b/ChattoAdditions/Source/Chat Items/BaseMessage/Views/BaseMessageCollectionViewCellDefaultStyle.swift
@@ -186,11 +186,11 @@ public extension BaseMessageCollectionViewCellDefaultStyle { // Default values
     private static let defaultIncomingColor = UIColor.bma_color(rgb: 0xE6ECF2)
     private static let defaultOutgoingColor = UIColor.bma_color(rgb: 0x3D68F5)
 
-    static public func createDefaultColors() -> Colors {
+    static func createDefaultColors() -> Colors {
         return Colors(incoming: self.defaultIncomingColor, outgoing: self.defaultOutgoingColor)
     }
 
-    static public func createDefaultBubbleBorderImages() -> BubbleBorderImages {
+    static func createDefaultBubbleBorderImages() -> BubbleBorderImages {
         return BubbleBorderImages(
             borderIncomingTail: UIImage(named: "bubble-incoming-border-tail", in: Bundle(for: Class.self), compatibleWith: nil)!,
             borderIncomingNoTail: UIImage(named: "bubble-incoming-border", in: Bundle(for: Class.self), compatibleWith: nil)!,
@@ -199,7 +199,7 @@ public extension BaseMessageCollectionViewCellDefaultStyle { // Default values
         )
     }
 
-    static public func createDefaultFailedIconImages() -> FailedIconImages {
+    static func createDefaultFailedIconImages() -> FailedIconImages {
         let normal = {
             return UIImage(named: "base-message-failed-icon", in: Bundle(for: Class.self), compatibleWith: nil)!
         }
@@ -209,11 +209,11 @@ public extension BaseMessageCollectionViewCellDefaultStyle { // Default values
         )
     }
 
-    static public func createDefaultDateTextStyle() -> DateTextStyle {
+    static func createDefaultDateTextStyle() -> DateTextStyle {
         return DateTextStyle(font: UIFont.systemFont(ofSize: 12), color: UIColor.bma_color(rgb: 0x9aa3ab))
     }
 
-    static public func createDefaultLayoutConstants() -> BaseMessageCollectionViewCellLayoutConstants {
+    static func createDefaultLayoutConstants() -> BaseMessageCollectionViewCellLayoutConstants {
         return BaseMessageCollectionViewCellLayoutConstants(horizontalMargin: 11,
                                                             horizontalInterspacing: 4,
                                                             horizontalTimestampMargin: 11,
@@ -223,7 +223,7 @@ public extension BaseMessageCollectionViewCellDefaultStyle { // Default values
     private static let selectionIndicatorIconSelected = UIImage(named: "base-message-checked-icon", in: Bundle(for: Class.self), compatibleWith: nil)!.bma_tintWithColor(BaseMessageCollectionViewCellDefaultStyle.defaultOutgoingColor)
     private static let selectionIndicatorIconDeselected = UIImage(named: "base-message-unchecked-icon", in: Bundle(for: Class.self), compatibleWith: nil)!.bma_tintWithColor(UIColor.bma_color(rgb: 0xC6C6C6))
 
-    static public func createDefaultSelectionIndicatorStyle() -> SelectionIndicatorStyle {
+    static func createDefaultSelectionIndicatorStyle() -> SelectionIndicatorStyle {
         return SelectionIndicatorStyle(
             margins: UIEdgeInsets(top: 0, left: 10, bottom: 0, right: 10),
             selectedIcon: self.selectionIndicatorIconSelected,

--- a/ChattoAdditions/Source/Chat Items/PhotoMessages/Views/PhotoMessageCollectionViewCellDefaultStyle.swift
+++ b/ChattoAdditions/Source/Chat Items/PhotoMessages/Views/PhotoMessageCollectionViewCellDefaultStyle.swift
@@ -174,7 +174,7 @@ open class PhotoMessageCollectionViewCellDefaultStyle: PhotoMessageCollectionVie
 
 public extension PhotoMessageCollectionViewCellDefaultStyle { // Default values
 
-    static public func createDefaultBubbleMasks() -> BubbleMasks {
+    static func createDefaultBubbleMasks() -> BubbleMasks {
         return BubbleMasks(
             incomingTail: UIImage(named: "bubble-incoming-tail", in: Bundle(for: Class.self), compatibleWith: nil)!,
             incomingNoTail: UIImage(named: "bubble-incoming", in: Bundle(for: Class.self), compatibleWith: nil)!,
@@ -184,7 +184,7 @@ public extension PhotoMessageCollectionViewCellDefaultStyle { // Default values
         )
     }
 
-    static public func createDefaultSizes() -> Sizes {
+    static func createDefaultSizes() -> Sizes {
         return Sizes(
             aspectRatioIntervalForSquaredSize: 0.90...1.10,
             photoSizeLandscape: CGSize(width: 210, height: 136),
@@ -193,7 +193,7 @@ public extension PhotoMessageCollectionViewCellDefaultStyle { // Default values
         )
     }
 
-    static public func createDefaultColors() -> Colors {
+    static func createDefaultColors() -> Colors {
         return Colors(
             placeholderIconTintIncoming: UIColor.bma_color(rgb: 0xced6dc),
             placeholderIconTintOutgoing: UIColor.bma_color(rgb: 0x508dfc),

--- a/ChattoAdditions/Source/Chat Items/TextMessages/Views/TextMessageCollectionViewCellDefaultStyle.swift
+++ b/ChattoAdditions/Source/Chat Items/TextMessages/Views/TextMessageCollectionViewCellDefaultStyle.swift
@@ -149,7 +149,7 @@ open class TextMessageCollectionViewCellDefaultStyle: TextMessageCollectionViewC
 
 public extension TextMessageCollectionViewCellDefaultStyle { // Default values
 
-    static public func createDefaultBubbleImages() -> BubbleImages {
+    static func createDefaultBubbleImages() -> BubbleImages {
         return BubbleImages(
             incomingTail: UIImage(named: "bubble-incoming-tail", in: Bundle(for: Class.self), compatibleWith: nil)!,
             incomingNoTail: UIImage(named: "bubble-incoming", in: Bundle(for: Class.self), compatibleWith: nil)!,
@@ -158,7 +158,7 @@ public extension TextMessageCollectionViewCellDefaultStyle { // Default values
         )
     }
 
-    static public func createDefaultTextStyle() -> TextStyle {
+    static func createDefaultTextStyle() -> TextStyle {
         return TextStyle(
             font: UIFont.systemFont(ofSize: 16),
             incomingColor: UIColor.black,

--- a/ChattoAdditions/Source/Common/AnimationUtils.swift
+++ b/ChattoAdditions/Source/Common/AnimationUtils.swift
@@ -37,7 +37,7 @@ public extension CABasicAnimation {
 }
 
 public extension CATransaction {
-    public static func performWithDisabledActions(block: () -> Void) {
+    static func performWithDisabledActions(block: () -> Void) {
         self.begin()
         self.setDisableActions(true)
         block()

--- a/ChattoAdditions/Source/Common/UIColor+Additions.swift
+++ b/ChattoAdditions/Source/Common/UIColor+Additions.swift
@@ -29,7 +29,7 @@ public extension UIColor {
         return UIColor(red: CGFloat((rgb & 0xFF0000) >> 16) / 255.0, green: CGFloat((rgb & 0xFF00) >> 8) / 255.0, blue: CGFloat((rgb & 0xFF)) / 255.0, alpha: 1.0)
     }
 
-    public func bma_blendWithColor(_ color: UIColor) -> UIColor {
+    func bma_blendWithColor(_ color: UIColor) -> UIColor {
         var r1: CGFloat = 0, r2: CGFloat = 0
         var g1: CGFloat = 0, g2: CGFloat = 0
         var b1: CGFloat = 0, b2: CGFloat = 0

--- a/ChattoAdditions/Source/Common/UIEdgeInsets+Additions.swift
+++ b/ChattoAdditions/Source/Common/UIEdgeInsets+Additions.swift
@@ -26,11 +26,11 @@ import UIKit
 import CoreGraphics
 
 public extension UIEdgeInsets {
-    public var bma_horziontalInset: CGFloat {
+    var bma_horziontalInset: CGFloat {
         return self.left + self.right
     }
 
-    public var bma_verticalInset: CGFloat {
+    var bma_verticalInset: CGFloat {
         return self.top + self.bottom
     }
 }

--- a/ChattoAdditions/Source/Common/UIImage+Additions.swift
+++ b/ChattoAdditions/Source/Common/UIImage+Additions.swift
@@ -25,7 +25,7 @@
 import UIKit
 
 public extension UIImage {
-    public func bma_tintWithColor(_ color: UIColor) -> UIImage {
+    func bma_tintWithColor(_ color: UIColor) -> UIImage {
         let rect = CGRect(origin: CGPoint.zero, size: self.size)
         UIGraphicsBeginImageContextWithOptions(rect.size, false, self.scale)
         let context = UIGraphicsGetCurrentContext()!
@@ -37,7 +37,7 @@ public extension UIImage {
         return image.resizableImage(withCapInsets: self.capInsets)
     }
 
-    public func bma_blendWithColor(_ color: UIColor) -> UIImage {
+    func bma_blendWithColor(_ color: UIColor) -> UIImage {
         let rect = CGRect(origin: CGPoint.zero, size: self.size)
         UIGraphicsBeginImageContextWithOptions(rect.size, false, UIScreen.main.scale)
         let context = UIGraphicsGetCurrentContext()!
@@ -54,7 +54,7 @@ public extension UIImage {
         return image.resizableImage(withCapInsets: self.capInsets)
     }
 
-    public static func bma_imageWithColor(_ color: UIColor, size: CGSize) -> UIImage {
+    static func bma_imageWithColor(_ color: UIColor, size: CGSize) -> UIImage {
         let rect = CGRect(origin: CGPoint.zero, size: size)
         UIGraphicsBeginImageContextWithOptions(size, false, 0)
         color.setFill()

--- a/ChattoAdditions/Source/Input/Photos/Camera/LiveCameraCell.swift
+++ b/ChattoAdditions/Source/Input/Photos/Camera/LiveCameraCell.swift
@@ -127,6 +127,9 @@ class LiveCameraCell: UICollectionViewCell {
             self.iconImageView.image = self.appearance.cameraImageProvider()
         case .restricted, .denied:
             self.iconImageView.image = self.appearance.cameraLockImageProvider()
+        @unknown default:
+            assertionFailure("Unsupported \(type(of: self.authorizationStatus)) case: \(self.authorizationStatus).")
+            self.iconImageView.image = self.appearance.cameraLockImageProvider()
         }
         self.setNeedsLayout()
     }

--- a/ChattoAdditions/Source/Input/Photos/Camera/LiveCameraCellPresenter.swift
+++ b/ChattoAdditions/Source/Input/Photos/Camera/LiveCameraCellPresenter.swift
@@ -187,6 +187,9 @@ public final class LiveCameraCellPresenter {
             return false
         case .authorized:
             return true
+        @unknown default:
+            assertionFailure("Unsupported \(type(of: self.cameraAuthorizationStatus)) case: \(self.cameraAuthorizationStatus).")
+            return false
         }
     }
 

--- a/ChattoAdditions/Source/UI Components/CircleProgressIndicatorView/CircleProgressIndicatorView.swift
+++ b/ChattoAdditions/Source/UI Components/CircleProgressIndicatorView/CircleProgressIndicatorView.swift
@@ -225,11 +225,11 @@ public final class CircleProgressIndicatorView: UIView {
 
 public extension CircleProgressIndicatorView {
 
-    public convenience init(size: CGSize) {
+    convenience init(size: CGSize) {
         self.init(frame: CGRect(x: 0, y: 0, width: size.width, height: size.height))
     }
 
-    public static func `default`() -> CircleProgressIndicatorView {
+    static func `default`() -> CircleProgressIndicatorView {
         return CircleProgressIndicatorView(size: CGSize(width: 28, height: 28))
     }
 }


### PR DESCRIPTION
In order to support module stability feature, I switched Chatto & ChattoAdditions to Swift 5 source compatibility mode and enabled `BUILD_LIBRARY_FOR_DISTRIBUTION` option for release configurations.
There are no logical changes, also, I did not touch some generic warnings.