### PR TITLE
Disable BUILD_LIBRARY_FOR_DISTRIBUTION option

### DIFF
--- a/Chatto/Chatto.xcodeproj/project.pbxproj
+++ b/Chatto/Chatto.xcodeproj/project.pbxproj
@@ -451,7 +451,6 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
-				BUILD_LIBRARY_FOR_DISTRIBUTION = YES;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CLANG_CXX_LIBRARY = "libc++";
 				CLANG_ENABLE_MODULES = YES;

--- a/ChattoAdditions/ChattoAdditions.xcodeproj/project.pbxproj
+++ b/ChattoAdditions/ChattoAdditions.xcodeproj/project.pbxproj
@@ -979,7 +979,6 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
-				BUILD_LIBRARY_FOR_DISTRIBUTION = YES;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CLANG_CXX_LIBRARY = "libc++";
 				CLANG_ENABLE_MODULES = YES;


### PR DESCRIPTION
We have to disable the option due to two blockers with Swift Toolchain: [SR-11704](https://bugs.swift.org/browse/SR-11704), [SR-11466](https://bugs.swift.org/browse/SR-11466).