### PR TITLE
Allow to specify orientation in default keyboard height

### DIFF
--- a/ChattoAdditions/Source/Common/ScreenMetric.swift
+++ b/ChattoAdditions/Source/Common/ScreenMetric.swift
@@ -155,7 +155,11 @@ extension UIScreen {
     }
 
     public var defaultKeyboardHeightForCurrentOrientation: CGFloat {
-        if UIDevice.current.orientation.isPortrait {
+        return self.defaultKeyboardHeight(isPortrait: UIDevice.current.orientation.isPortrait)
+    }
+
+    public func defaultKeyboardHeight(isPortrait: Bool) -> CGFloat {
+        if isPortrait {
             return self.defaultPortraitKeyboardHeight
         } else {
             return self.defaultLandscapeKeyboardHeight


### PR DESCRIPTION
For portrait mode only apps we can not rely on UIDevice.current.orientation to get current keyboard orientation because it returns orientation of the device, not the interface. 

For example: 

<img width="1028" alt="Screenshot 2019-12-13 at 12 30 25" src="https://user-images.githubusercontent.com/3374306/70789598-5bc99100-1da4-11ea-955d-b7404317c5bb.png">

```
(lldb) p UIDevice.current.orientation
(UIDeviceOrientation) $R0 = landscapeLeft
(lldb) p UIApplication.shared.keyWindow?.windowScene?.interfaceOrientation
(UIInterfaceOrientation?) $R2 = portrait
```