### PR TITLE
Made overridden inputAccessoryView read-write

### DIFF
--- a/Chatto/Source/ChatController/Collaborators/BaseChatViewControllerView.swift
+++ b/Chatto/Source/ChatController/Collaborators/BaseChatViewControllerView.swift
@@ -35,6 +35,11 @@ final class BaseChatViewControllerView: UIView, BaseChatViewControllerViewProtoc
     var bmaInputAccessoryView: UIView?
 
     override var inputAccessoryView: UIView? {
-        return self.bmaInputAccessoryView
+        get {
+            return self.bmaInputAccessoryView
+        }
+        set {
+            self.bmaInputAccessoryView = newValue
+        }
     }
 }


### PR DESCRIPTION
In the [inputAccessoryView doc](https://developer.apple.com/documentation/uikit/uiresponder/1621119-inputaccessoryview) Apple explicitly mentioned that the overridden property should be read-write. Read-only access can cause problems similar to one described [here](https://forums.developer.apple.com/thread/99743) 

This fix adds setter to the overridden variable