### PR TITLE
Fix for #FB7543829 Apple Radar about a crash on termination

### DIFF
--- a/Chatto/Source/ChatController/Collaborators/KeyboardTracker.swift
+++ b/Chatto/Source/ChatController/Collaborators/KeyboardTracker.swift
@@ -246,18 +246,18 @@ private class KeyboardTrackingView: UIView {
         return self.preferredSize
     }
 
-    override func willMove(toSuperview newSuperview: UIView?) {
+    override func didMoveToSuperview() {
         if let observedView = self.observedView {
             observedView.removeObserver(self, forKeyPath: "center")
             self.observedView = nil
         }
 
-        if let newSuperview = newSuperview {
+        if let newSuperview = self.superview {
             newSuperview.addObserver(self, forKeyPath: "center", options: [.new, .old], context: nil)
             self.observedView = newSuperview
         }
 
-        super.willMove(toSuperview: newSuperview)
+        super.didMoveToSuperview()
     }
 
     override func observeValue(forKeyPath keyPath: String?,


### PR DESCRIPTION
Hello there,

This is a fix for the problem ([FB7543829](https://openradar.appspot.com/radar?id=4945999835430912)) with crashes when the user terminates an application when a keyboard has a highlighted suggestion in the accessory view.

The idea behind the fix was taken from this [discussion](https://forums.developer.apple.com/thread/125447). In general, we set up an observer in the `willMove(toSuperview:)` function but the [documentation](https://developer.apple.com/documentation/uikit/uiview/1622629-willmove) says explicitly that the function "Tells the view that its superview is about to change to the specified superview". Pay attention to the "is about to change" phrase. So, it is not guaranteed here that the `superview` will persist.

So, to fix the problem I moved the setup of the observer to the `didMoveToSuperview()` and it seems that the change has fixed the problem. After testing it manually, I did not find any problems and the change seems safe and harmless to me.

What do you think?