### PR TITLE
Highlight message

### DIFF
--- a/Chatto/Source/Chat Items/BaseChatItemPresenter.swift
+++ b/Chatto/Source/Chat Items/BaseChatItemPresenter.swift
@@ -116,4 +116,8 @@ open class BaseChatItemPresenter<CellT: UICollectionViewCell>: ChatItemPresenter
     open func performMenuControllerAction(_ action: Selector) {
         assert(self.canPerformMenuControllerAction(action))
     }
+
+    // MARK: - ChatItemSpotlighting
+
+    open func spotlight() {}
 }

--- a/Chatto/Source/Chat Items/ChatItemProtocolDefinitions.swift
+++ b/Chatto/Source/Chat Items/ChatItemProtocolDefinitions.swift
@@ -40,7 +40,15 @@ public protocol ChatItemMenuPresenterProtocol {
     func performMenuControllerAction(_ action: Selector)
 }
 
-public protocol ChatItemPresenterProtocol: AnyObject, ChatItemMenuPresenterProtocol {
+public protocol ChatItemSpotlighting {
+    func spotlight()
+}
+
+extension ChatItemSpotlighting {
+    public func spotlight() {}
+}
+
+public protocol ChatItemPresenterProtocol: AnyObject, ChatItemMenuPresenterProtocol, ChatItemSpotlighting {
     static func registerCells(_ collectionView: UICollectionView)
 
     var isItemUpdateSupported: Bool { get }

--- a/ChattoAdditions/Source/Chat Items/CompoundMessage/CompoundMessagePresenter.swift
+++ b/ChattoAdditions/Source/Chat Items/CompoundMessage/CompoundMessagePresenter.swift
@@ -264,6 +264,12 @@ open class CompoundMessagePresenter<ViewModelBuilderT, InteractionHandlerT>
         self.menuPresenter?.performMenuControllerAction(action)
     }
 
+    // MARK: - ChatItemSpotlighting
+
+    override open func spotlight() {
+        self.cell?.bubbleView?.spotlight()
+    }
+
     // MARK: - MessageContentPresenterDelegate
 
     public func presenterDidInvalidateLayout(_ presenter: MessageContentPresenterProtocol) {

--- a/ChattoAdditions/Source/Chat Items/CompoundMessage/Views/CompoundBubbleView.swift
+++ b/ChattoAdditions/Source/Chat Items/CompoundMessage/Views/CompoundBubbleView.swift
@@ -82,6 +82,32 @@ public final class CompoundBubbleView: UIView, MaximumLayoutWidthSpecificable, B
         didSet { self.setNeedsLayout() }
     }
 
+    // MARK: - Spotlighting
+
+    public func spotlight() {
+        // Covers the case when bubble is hidden
+        guard self.backgroundColor != nil else { return }
+
+        guard let viewModel = self.viewModel,
+              let style = self.style,
+              let spotlightedColor = style.spotlightedBackgroundColor(forViewModel: viewModel),
+              let originalColor = style.backgroundColor(forViewModel: viewModel) else { return }
+
+        let durationInMs = Int(style.spotlightDuration(forViewModel: viewModel) * 1000)
+
+        self.animateBackgroundColorChange(to: spotlightedColor)
+        DispatchQueue.main.asyncAfter(deadline: .now() + .milliseconds(durationInMs)) { [weak self] in
+            self?.animateBackgroundColorChange(to: originalColor)
+        }
+    }
+
+    private static let backgroundColorChangeAnimationDuration: TimeInterval = 0.1
+    private func animateBackgroundColorChange(to color: UIColor) {
+        UIView.animate(withDuration: Self.backgroundColorChangeAnimationDuration) { [weak self] in
+            self?.backgroundColor = color
+        }
+    }
+
     // MARK: - MaximumLayoutWidthSpecificable
 
     public var preferredMaxLayoutWidth: CGFloat = 0

--- a/ChattoAdditions/Source/Chat Items/CompoundMessage/Views/CompoundBubbleViewStyle.swift
+++ b/ChattoAdditions/Source/Chat Items/CompoundMessage/Views/CompoundBubbleViewStyle.swift
@@ -28,6 +28,7 @@ public protocol CompoundBubbleViewStyleProtocol {
     var hideBubbleForSingleContent: Bool { get }
     func backgroundColor(forViewModel viewModel: ViewModel) -> UIColor?
     func spotlightedBackgroundColor(forViewModel viewModel: ViewModel) -> UIColor?
+    func spotlightDuration(forViewModel viewModel: ViewModel) -> TimeInterval
     func maskingImage(forViewModel viewModel: ViewModel) -> UIImage?
     func borderImage(forViewModel viewModel: ViewModel) -> UIImage?
     func tailWidth(forViewModel viewModel: ViewModel) -> CGFloat
@@ -57,15 +58,18 @@ public final class DefaultCompoundBubbleViewStyle: CompoundBubbleViewStyleProtoc
     private let baseStyle: BaseMessageCollectionViewCellDefaultStyle
     private let bubbleMasks: BubbleMasks
     private let spotlightBrightnessScale: CGFloat
+    private let spotlightDuration: TimeInterval
 
     public init(baseStyle: BaseMessageCollectionViewCellDefaultStyle = BaseMessageCollectionViewCellDefaultStyle(),
                 bubbleMasks: BubbleMasks = .default,
                 hideBubbleForSingleContent: Bool = false,
-                spotlightBrightnessScale: CGFloat = 0.85) {
+                spotlightBrightnessScale: CGFloat = 0.85,
+                spotlightDuration: TimeInterval = 0.5) {
         self.baseStyle = baseStyle
         self.bubbleMasks = bubbleMasks
         self.hideBubbleForSingleContent = hideBubbleForSingleContent
         self.spotlightBrightnessScale = spotlightBrightnessScale
+        self.spotlightDuration = spotlightDuration
     }
 
     // MARK: CompoundBubbleViewStyleProtocol
@@ -78,6 +82,10 @@ public final class DefaultCompoundBubbleViewStyle: CompoundBubbleViewStyleProtoc
 
     public func spotlightedBackgroundColor(forViewModel viewModel: ViewModel) -> UIColor? {
         self.backgroundColor(forViewModel: viewModel)?.changeBrightness(to: self.spotlightBrightnessScale)
+    }
+
+    public func spotlightDuration(forViewModel viewModel: ViewModel) -> TimeInterval {
+        self.spotlightDuration
     }
 
     public func maskingImage(forViewModel viewModel: ViewModel) -> UIImage? {

--- a/ChattoAdditions/Source/Chat Items/CompoundMessage/Views/CompoundBubbleViewStyle.swift
+++ b/ChattoAdditions/Source/Chat Items/CompoundMessage/Views/CompoundBubbleViewStyle.swift
@@ -27,6 +27,7 @@ public protocol CompoundBubbleViewStyleProtocol {
     typealias ViewModel = MessageViewModelProtocol
     var hideBubbleForSingleContent: Bool { get }
     func backgroundColor(forViewModel viewModel: ViewModel) -> UIColor?
+    func spotlightedBackgroundColor(forViewModel viewModel: ViewModel) -> UIColor?
     func maskingImage(forViewModel viewModel: ViewModel) -> UIImage?
     func borderImage(forViewModel viewModel: ViewModel) -> UIImage?
     func tailWidth(forViewModel viewModel: ViewModel) -> CGFloat
@@ -55,13 +56,16 @@ public final class DefaultCompoundBubbleViewStyle: CompoundBubbleViewStyleProtoc
 
     private let baseStyle: BaseMessageCollectionViewCellDefaultStyle
     private let bubbleMasks: BubbleMasks
+    private let spotlightBrightnessScale: CGFloat
 
     public init(baseStyle: BaseMessageCollectionViewCellDefaultStyle = BaseMessageCollectionViewCellDefaultStyle(),
                 bubbleMasks: BubbleMasks = .default,
-                hideBubbleForSingleContent: Bool = false) {
+                hideBubbleForSingleContent: Bool = false,
+                spotlightBrightnessScale: CGFloat = 0.85) {
         self.baseStyle = baseStyle
         self.bubbleMasks = bubbleMasks
         self.hideBubbleForSingleContent = hideBubbleForSingleContent
+        self.spotlightBrightnessScale = spotlightBrightnessScale
     }
 
     // MARK: CompoundBubbleViewStyleProtocol
@@ -70,6 +74,10 @@ public final class DefaultCompoundBubbleViewStyle: CompoundBubbleViewStyleProtoc
 
     public func backgroundColor(forViewModel viewModel: ViewModel) -> UIColor? {
         return viewModel.isIncoming ? self.baseStyle.baseColorIncoming : self.baseStyle.baseColorOutgoing
+    }
+
+    public func spotlightedBackgroundColor(forViewModel viewModel: ViewModel) -> UIColor? {
+        self.backgroundColor(forViewModel: viewModel)?.changeBrightness(to: self.spotlightBrightnessScale)
     }
 
     public func maskingImage(forViewModel viewModel: ViewModel) -> UIImage? {
@@ -109,5 +117,25 @@ extension DefaultCompoundBubbleViewStyle.BubbleMasks {
             outgoingNoTail: UIImage(named: "bubble-outgoing", in: bundle, compatibleWith: nil)!,
             tailWidth: 6
         )
+    }
+}
+
+private extension UIColor {
+    func changeBrightness(to scale: CGFloat) -> UIColor {
+        var red: CGFloat = 0
+        var green: CGFloat = 0
+        var blue: CGFloat = 0
+        var alpha: CGFloat = 0
+
+        guard self.getRed(&red, green: &green, blue: &blue, alpha: &alpha) else {
+            assertionFailure("Couldn't get colors of: \(self)")
+            return self
+        }
+
+        red *= scale
+        green *= scale
+        blue *= scale
+
+        return UIColor(red: red, green: green, blue: blue, alpha: alpha)
     }
 }


### PR DESCRIPTION
This pull requests adds ability to **spotlight** the message when using `scrollToItem` method on `BaseChatViewController`

For compound messages it's supported out of the box. It'll tint background color of `CompoundBubbleView`.
If you'd like to support other presenters, override `spotlight` method in your presenter.

You can specify which color to use for tinting background of `CompoundBubbleView` in `DefaultCompoundBubbleViewStyle`. 
By default we're reducing brightness of background color by 15%.

You can also change how long bubble is going to be spotlighted in `DefaultCompoundBubbleViewStyle`. 
Default value is 0.5 seconds.