### PR TITLE
Do not restart camera capture when camera picker is presented

### DIFF
--- a/ChattoAdditions/Source/Input/Photos/Camera/LiveCameraCellPresenter.swift
+++ b/ChattoAdditions/Source/Input/Photos/Camera/LiveCameraCellPresenter.swift
@@ -93,6 +93,7 @@ public final class LiveCameraCellPresenter {
 
         if self.cell === cell {
             cell.captureLayer = nil
+            self.isCellAddedToWindow = false
             self.cell = nil
             self.stopCapturing()
         }


### PR DESCRIPTION
There is a bug that is mostly noticeable on iOS 14 that introduced camera capture indicator in the status bar. 

Steps:

1. Open photos input
2. Grant all permissions
3. Tap on camera preview
4. Take a photo
5. Send this photo

Actual result:
There is a green indicator in the status bar

Expected result:
There shouldn't be any indicator

The issue was that when LiveCameraCellPresenter.cameraPickerDidDisappear() is called presenter restarts camera capture. However, at that moment photos input is already hidden and camera preview cell is not visible, so we shouldn't start it. 