### PR TITLE
iOS 14: Fix infinite layout loop when chat is empty

### DIFF
--- a/Chatto/Source/ChatController/BaseChatViewController.swift
+++ b/Chatto/Source/ChatController/BaseChatViewController.swift
@@ -259,7 +259,10 @@ open class BaseChatViewController: UIViewController,
 
     private func updateInputContainerBottomBaseOffset() {
         if #available(iOS 11.0, *) {
-            self.inputContainerBottomBaseOffset = self.bottomLayoutGuide.length
+            let offset = self.bottomLayoutGuide.length
+            if self.inputContainerBottomBaseOffset != offset {
+                self.inputContainerBottomBaseOffset = offset
+            }
         } else {
             // If we have been pushed on nav controller and hidesBottomBarWhenPushed = true, then ignore bottomLayoutMargin
             // because it has incorrect value when we actually have a bottom bar (tabbar)


### PR DESCRIPTION
There is an infinite layout loop that occurs inside `BaseChatViewControllerView` under these conditions:

1. Chat is empty
2. Project is compiled with Xcode 12
3. App is running on iOS 14
4. Latest pod Chatto v3.6.0

I should note that the same code built using Xcode 11.x and submitted to the App Store does not cause the issue on iOS 14, so Xcode 12 makes the difference.