### PR TITLE
Fix false positive test runs

### DIFF
--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -o pipefail
+
 WORKSPACE='Chatto.xcworkspace'
 SCHEME='Chatto'
 


### PR DESCRIPTION
Because we have pipe to `xcpretty` at the end of the `test.sh` script, returned **exit** code is zero even if `xcodebuild` fails.
We need to enable pipefail option in order to fix that behaviour.
For more information see [documentation on set](https://www.gnu.org/software/bash/manual/html_node/The-Set-Builtin.html).
