### PR TITLE
Add empty scroll view delegate methods

### DIFF
--- a/Chatto/Source/ChatController/BaseChatViewController+Scrolling.swift
+++ b/Chatto/Source/ChatController/BaseChatViewController+Scrolling.swift
@@ -190,6 +190,9 @@ extension BaseChatViewController {
         self.autoLoadMoreContentIfNeeded()
     }
 
+    open func scrollViewWillEndDragging(_ scrollView: UIScrollView, withVelocity velocity: CGPoint, targetContentOffset: UnsafeMutablePointer<CGPoint>) {}
+    open func scrollViewWillBeginDragging(_ scrollView: UIScrollView) {}
+
     public func autoLoadMoreContentIfNeeded() {
         guard self.autoLoadingEnabled, let dataSource = self.chatDataSource else { return }
 


### PR DESCRIPTION
In Xcode 12 those methods won't be called for subclasses unless we define them in class