### PR TITLE
Added support for Swift Package Manager

### DIFF
--- a/ChattoAdditions/Source/Common/Bundle+ChattoAdditionsResources.swift
+++ b/ChattoAdditions/Source/Common/Bundle+ChattoAdditionsResources.swift
@@ -27,8 +27,10 @@ import Foundation
 extension Bundle {
     static let resources: Bundle = {
         let bundle = Bundle(for: BundleToken.self)
-        let path = bundle.path(forResource: "ChattoAdditionsResources", ofType: "bundle")
-        return Bundle(path: path!)!
+        guard let path = bundle.path(forResource: "ChattoAdditionsResources", ofType: "bundle") else {
+            return Bundle.module
+        }
+        return Bundle(path: path)!
     }()
 }
 

--- a/ChattoAdditions/Source/Common/Bundle+ChattoAdditionsResources.swift
+++ b/ChattoAdditions/Source/Common/Bundle+ChattoAdditionsResources.swift
@@ -21,16 +21,17 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-
 import Foundation
 
 extension Bundle {
     static let resources: Bundle = {
         let bundle = Bundle(for: BundleToken.self)
-        guard let path = bundle.path(forResource: "ChattoAdditionsResources", ofType: "bundle") else {
+        #if SWIFT_PACKAGE
             return Bundle.module
-        }
-        return Bundle(path: path)!
+        #else
+            let path = bundle.path(forResource: "ChattoAdditionsResources", ofType: "bundle")
+            return Bundle(path: path!)!
+        #endif
     }()
 }
 

--- a/ChattoAdditions/Source/Input/ExpandableChatInputBarPresenter.swift
+++ b/ChattoAdditions/Source/Input/ExpandableChatInputBarPresenter.swift
@@ -22,6 +22,8 @@
  THE SOFTWARE.
  */
 
+import Foundation
+import UIKit
 import Chatto
 
 @objc

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,21 @@
+// swift-tools-version:5.3
+
+import PackageDescription
+
+let package = Package(
+    name: "Chatto",
+    platforms: [.iOS(.v9)],
+    products: [
+        .library(name: "Chatto", targets: ["Chatto"]),
+        .library(name: "ChattoAdditions", targets: ["ChattoAdditions"]),
+    ],
+    targets: [
+        .target(
+            name: "Chatto",
+            dependencies: [],
+            path: "Chatto/Source"),
+        .target(
+            name: "ChattoAdditions",
+            dependencies: ["Chatto"],
+            path: "ChattoAdditions/Source"),
+    ])


### PR DESCRIPTION
Added support for SPM (Swift Package Manager) without effecting support for Cocoapods etc.

**Problem** 
Adding SPM support is hard for this project because you can't replicate `ChattoAdditionsResources` target using SPM.

**How it works**
Instead of trying to add a target that replicates `ChattoAdditionsResources` inside `Package.swift`. Which to my knowledge is not possible with `swift-tools-version:5.3`. I have instead modified the static variable `resources` to return `Bundle.module`([Method recommended by Apple](https://developer.apple.com/documentation/swift_packages/bundling_resources_with_a_swift_package#3578939)) ~~when there is no `ChattoAdditionsResources.bundle` found aka the package was built by SPM. If the project is built by Cocoapods or Carthage or manually `ChattoAdditionsResources.bundle` will exist and work just as it did previously.~~ when `SWIFT_PACKAGE` is defined

Please let me know if you have any questions

Fixes #621