### PR TITLE
Add Double tap handler to BaseMessageCollectionViewCell & MessageInteractionHandler

### DIFF
--- a/ChattoAdditions/Source/Chat Items/BaseMessage/BaseMessagePresenter.swift
+++ b/ChattoAdditions/Source/Chat Items/BaseMessage/BaseMessagePresenter.swift
@@ -40,6 +40,7 @@ public protocol BaseMessageInteractionHandlerProtocol {
     func userDidTapOnFailIcon(message: MessageType, viewModel: ViewModelType, failIconView: UIView)
     func userDidTapOnAvatar(message: MessageType, viewModel: ViewModelType)
     func userDidTapOnBubble(message: MessageType, viewModel: ViewModelType)
+    func userDidDoubleTapOnBubble(message: MessageType, viewModel: ViewModelType)
     func userDidBeginLongPressOnBubble(message: MessageType, viewModel: ViewModelType)
     func userDidEndLongPressOnBubble(message: MessageType, viewModel: ViewModelType)
     func userDidSelectMessage(message: MessageType, viewModel: ViewModelType)
@@ -131,6 +132,10 @@ open class BaseMessagePresenter<BubbleViewT, ViewModelBuilderT, InteractionHandl
                 guard let sSelf = self else { return }
                 sSelf.onCellBubbleTapped()
             }
+            cell.onBubbleDoubleTapped = { [weak self] (cell) in
+                guard let sSelf = self else { return }
+                sSelf.onCellBubbleDoubleTapped()
+            }
             cell.onBubbleLongPressBegan = { [weak self] (cell) in
                 guard let sSelf = self else { return }
                 sSelf.onCellBubbleLongPressBegan()
@@ -207,6 +212,10 @@ open class BaseMessagePresenter<BubbleViewT, ViewModelBuilderT, InteractionHandl
 
     open func onCellBubbleTapped() {
         self.interactionHandler?.userDidTapOnBubble(message: self.messageModel, viewModel: self.messageViewModel)
+    }
+
+    open func onCellBubbleDoubleTapped() {
+        self.interactionHandler?.userDidDoubleTapOnBubble(message: self.messageModel, viewModel: self.messageViewModel)
     }
 
     open func onCellBubbleLongPressBegan() {

--- a/ChattoAdditions/Source/Chat Items/BaseMessage/Views/BaseMessageCollectionViewCell.swift
+++ b/ChattoAdditions/Source/Chat Items/BaseMessage/Views/BaseMessageCollectionViewCell.swift
@@ -167,8 +167,16 @@ open class BaseMessageCollectionViewCell<BubbleViewType>: UICollectionViewCell, 
 
     public private(set) lazy var tapGestureRecognizer: UITapGestureRecognizer = {
         let tapGestureRecognizer = UITapGestureRecognizer(target: self, action: #selector(BaseMessageCollectionViewCell.bubbleTapped(_:)))
+        tapGestureRecognizer.numberOfTapsRequired = 1
         tapGestureRecognizer.delegate = self
         return tapGestureRecognizer
+    }()
+
+    public private(set) lazy var doubleTapGestureRecognizer: UITapGestureRecognizer = {
+        let doubleTapGestureRecognizer = UITapGestureRecognizer(target: self, action: #selector(BaseMessageCollectionViewCell.bubbleDoubleTapped(_:)))
+        doubleTapGestureRecognizer.numberOfTapsRequired = 2
+        doubleTapGestureRecognizer.delegate = self
+        return doubleTapGestureRecognizer
     }()
 
     public private (set) lazy var longPressGestureRecognizer: UILongPressGestureRecognizer = {
@@ -190,7 +198,9 @@ open class BaseMessageCollectionViewCell<BubbleViewType>: UICollectionViewCell, 
         self.bubbleView.isExclusiveTouch = true
         self.bubbleView.addGestureRecognizer(self.tapGestureRecognizer)
         self.bubbleView.addGestureRecognizer(self.longPressGestureRecognizer)
+        self.bubbleView.addGestureRecognizer(self.doubleTapGestureRecognizer)
         self.tapGestureRecognizer.require(toFail: self.longPressGestureRecognizer)
+        self.tapGestureRecognizer.require(toFail: self.doubleTapGestureRecognizer)
         self.contentView.addSubview(self.avatarView)
         self.contentView.addSubview(self.bubbleView)
         self.contentView.addSubview(self.failedButton)
@@ -211,7 +221,7 @@ open class BaseMessageCollectionViewCell<BubbleViewType>: UICollectionViewCell, 
 
     open func gestureRecognizer(_ gestureRecognizer: UIGestureRecognizer, shouldRecognizeSimultaneouslyWith otherGestureRecognizer: UIGestureRecognizer) -> Bool {
         let allowLongPressGestureRecognizerToBeRecognizedWithAnyOtherGestureRecognizersExceptTapGestures = gestureRecognizer === self.longPressGestureRecognizer && !(otherGestureRecognizer is UITapGestureRecognizer)
-        let allowTapGestureRecognizerToBeRecognizedWithOtherTapGestures = gestureRecognizer === self.tapGestureRecognizer && otherGestureRecognizer is UITapGestureRecognizer
+        let allowTapGestureRecognizerToBeRecognizedWithOtherTapGestures = [self.tapGestureRecognizer, self.doubleTapGestureRecognizer].contains(gestureRecognizer) && otherGestureRecognizer is UITapGestureRecognizer
         return allowLongPressGestureRecognizerToBeRecognizedWithAnyOtherGestureRecognizersExceptTapGestures
             || allowTapGestureRecognizerToBeRecognizedWithOtherTapGestures
     }
@@ -505,6 +515,12 @@ open class BaseMessageCollectionViewCell<BubbleViewType>: UICollectionViewCell, 
     @objc
     func bubbleTapped(_ tapGestureRecognizer: UITapGestureRecognizer) {
         self.onBubbleTapped?(self)
+    }
+
+    public var onBubbleDoubleTapped: ((_ cell: BaseMessageCollectionViewCell) -> Void)?
+    @objc
+    func bubbleDoubleTapped(_ tapGestureRecognizer: UITapGestureRecognizer) {
+        self.onBubbleDoubleTapped?(self)
     }
 
     public var onBubbleLongPressBegan: ((_ cell: BaseMessageCollectionViewCell) -> Void)?

--- a/ChattoAdditions/Tests/Chat Items/BaseMessage/BaseMessagePresenterTests.swift
+++ b/ChattoAdditions/Tests/Chat Items/BaseMessage/BaseMessagePresenterTests.swift
@@ -58,6 +58,13 @@ class BaseMessagePresenterTests: XCTestCase {
         XCTAssertTrue(self.interactionHandler.didHandleTapOnBubble)
     }
 
+    func testThat_WhenCellIsDoubleTappedOnBubble_ThenInteractionHandlerHandlesEvent() {
+        let cell = PhotoMessageCollectionViewCell(frame: CGRect.zero)
+        self.presenter.configureCell(cell, decorationAttributes: self.decorationAttributes)
+        cell.bubbleDoubleTapped(UITapGestureRecognizer())
+        XCTAssertTrue(self.interactionHandler.didHandleDoubleTapOnBubble)
+    }
+
     func testThat_WhenCellIsBeginLongPressOnBubble_ThenInteractionHandlerHandlesEvent() {
         let cell = PhotoMessageCollectionViewCell(frame: CGRect.zero)
         self.presenter.configureCell(cell, decorationAttributes: self.decorationAttributes)

--- a/ChattoAdditions/Tests/Chat Items/BaseMessage/FakeMessageInteractionHandler.swift
+++ b/ChattoAdditions/Tests/Chat Items/BaseMessage/FakeMessageInteractionHandler.swift
@@ -48,6 +48,7 @@ public final class FakeMessageInteractionHandler: BaseMessageInteractionHandlerP
     var _userDidTapOnFailIcon = _UserDidTapOnFailIcon()
     var _userDidTapOnAvatar = _UserDidTapOnAvatar()
     var _userDidTapOnBubble = _UserDidTapOnBubble()
+    var _userDidDoubleTapOnBubble = _UserDidDoubleTapOnBubble()
     var _userDidBeginLongPressOnBubble = _UserDidBeginLongPressOnBubble()
     var _userDidEndLongPressOnBubble = _UserDidEndLongPressOnBubble()
     var _userDidSelectMessage = _UserDidSelectMessage()
@@ -80,6 +81,16 @@ public final class FakeMessageInteractionHandler: BaseMessageInteractionHandlerP
         } else {
             if !self.isNiceMock { fatalError("\(String(describing: self)) \(#function) is not implemented. Add your implementation or use .niceMock()") }
             self._userDidTapOnBubble.history.append((message, viewModel))
+        }
+    }
+
+    var onUserDidDoubleTapOnBubble: ((MessageType, ViewModelType) -> Void)? = nil
+    public func userDidDoubleTapOnBubble(message: MessageType, viewModel: ViewModelType) -> Void {
+        if let fakeImplementation = self.onUserDidDoubleTapOnBubble {
+            fakeImplementation(message, viewModel)
+        } else {
+            if !self.isNiceMock { fatalError("\(String(describing: self)) \(#function) is not implemented. Add your implementation or use .niceMock()") }
+            self._userDidDoubleTapOnBubble.history.append((message, viewModel))
         }
     }
 
@@ -141,6 +152,13 @@ public extension FakeMessageInteractionHandler {
     }
 
     struct _UserDidTapOnBubble {
+        var history: [(message: MessageType, viewModel: ViewModelType)] = []
+        var lastArgs: (message: MessageType, viewModel: ViewModelType)! { return self.history.last }
+        var callsCount: Int { return self.history.count }
+        var wasCalled: Bool { return self.callsCount > 0 }
+    }
+
+    struct _UserDidDoubleTapOnBubble {
         var history: [(message: MessageType, viewModel: ViewModelType)] = []
         var lastArgs: (message: MessageType, viewModel: ViewModelType)! { return self.history.last }
         var callsCount: Int { return self.history.count }

--- a/ChattoAdditions/Tests/Chat Items/PhotoMessages/PhotoMessagePresenterTests.swift
+++ b/ChattoAdditions/Tests/Chat Items/PhotoMessages/PhotoMessagePresenterTests.swift
@@ -106,6 +106,11 @@ class PhotoMessageTestHandler: BaseMessageInteractionHandlerProtocol {
         self.didHandleTapOnBubble = true
     }
 
+    var didHandleDoubleTapOnBubble = false
+    func userDidDoubleTapOnBubble(message: MessageType, viewModel: ViewModelType) {
+        self.didHandleDoubleTapOnBubble = true
+    }
+
     var didHandleBeginLongPressOnBubble = false
     func userDidBeginLongPressOnBubble(message: MessageType, viewModel: ViewModelType) {
         self.didHandleBeginLongPressOnBubble = true

--- a/ChattoAdditions/Tests/Chat Items/TextMessages/TextMessagePresenterTests.swift
+++ b/ChattoAdditions/Tests/Chat Items/TextMessages/TextMessagePresenterTests.swift
@@ -111,6 +111,8 @@ class TextMessageTestHandler: BaseMessageInteractionHandlerProtocol {
 
     func userDidTapOnBubble(message: MessageType, viewModel: ViewModelType) {}
 
+    func userDidDoubleTapOnBubble(message: MessageType, viewModel: ViewModelType) {}
+
     func userDidBeginLongPressOnBubble(message: MessageType, viewModel: ViewModelType) {}
 
     func userDidEndLongPressOnBubble(message: MessageType, viewModel: ViewModelType) {}

--- a/ChattoApp/ChattoApp/Source/Chat Items/Base Message/DemoMessageInteractionHandler.swift
+++ b/ChattoApp/ChattoApp/Source/Chat Items/Base Message/DemoMessageInteractionHandler.swift
@@ -46,6 +46,10 @@ final class DemoMessageInteractionHandler<Model: DemoMessageModelProtocol, ViewM
         print(#function)
     }
 
+    func userDidDoubleTapOnBubble(message: Model, viewModel: ViewModel) {
+        print(#function)
+    }
+
     func userDidBeginLongPressOnBubble(message: Model, viewModel: ViewModel) {
         print(#function)
     }


### PR DESCRIPTION
This is a copy of #691:

1. Added new gesture recogniser to BaseMessageCollectionViewCell, a bit updated delegate methods to work simultaneously with others.
2. Updated BaseMessageInteractionHandlerProtocol to have double-tap handler method.
3. BaseMessagePresenter translates new gesture event to interaction handler.
4. Unit-test for BaseMessagePresenter added.