### PR TITLE
Failed content in compound messages

### DIFF
--- a/ChattoAdditions/ChattoAdditions.xcodeproj/project.pbxproj
+++ b/ChattoAdditions/ChattoAdditions.xcodeproj/project.pbxproj
@@ -114,6 +114,9 @@
 		CDC6100B1FD8268200C2588E /* FakePhotosInputDataProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDC610091FD8267D00C2588E /* FakePhotosInputDataProvider.swift */; };
 		CDC6100D1FD8376000C2588E /* PhotosInputCellProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDC6100C1FD8376000C2588E /* PhotosInputCellProviderTests.swift */; };
 		CDE15F43205993FB005D86DD /* PhotosInputCameraPickerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDE15F42205993FB005D86DD /* PhotosInputCameraPickerTests.swift */; };
+		D6E3AEF625D6DF6000819A56 /* MessageViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6E3AEF525D6DF6000819A56 /* MessageViewModelTests.swift */; };
+		D6E3AEFC25D6E01900819A56 /* FakeMessageModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6E3AEFB25D6E01900819A56 /* FakeMessageModel.swift */; };
+		D6E3AF0125D6E6C500819A56 /* FakeMessageContentFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6E3AF0025D6E6C500819A56 /* FakeMessageContentFactory.swift */; };
 		DE51010D21B5670A009BC61C /* InputContainerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE51010C21B5670A009BC61C /* InputContainerView.swift */; };
 		E376C10524F8160B00069ECA /* PhotosInputPermissionsRequester.swift in Sources */ = {isa = PBXBuildFile; fileRef = E376C10324F8160B00069ECA /* PhotosInputPermissionsRequester.swift */; };
 		E3E0D60322EA1AA2006E2053 /* Comparable+Clamp.swift in Sources */ = {isa = PBXBuildFile; fileRef = E3E0D60222EA1AA2006E2053 /* Comparable+Clamp.swift */; };
@@ -287,6 +290,9 @@
 		CDC610091FD8267D00C2588E /* FakePhotosInputDataProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FakePhotosInputDataProvider.swift; sourceTree = "<group>"; };
 		CDC6100C1FD8376000C2588E /* PhotosInputCellProviderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhotosInputCellProviderTests.swift; sourceTree = "<group>"; };
 		CDE15F42205993FB005D86DD /* PhotosInputCameraPickerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhotosInputCameraPickerTests.swift; sourceTree = "<group>"; };
+		D6E3AEF525D6DF6000819A56 /* MessageViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageViewModelTests.swift; sourceTree = "<group>"; };
+		D6E3AEFB25D6E01900819A56 /* FakeMessageModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FakeMessageModel.swift; sourceTree = "<group>"; };
+		D6E3AF0025D6E6C500819A56 /* FakeMessageContentFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FakeMessageContentFactory.swift; sourceTree = "<group>"; };
 		DE51010C21B5670A009BC61C /* InputContainerView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = InputContainerView.swift; sourceTree = "<group>"; };
 		E376C10324F8160B00069ECA /* PhotosInputPermissionsRequester.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PhotosInputPermissionsRequester.swift; sourceTree = "<group>"; };
 		E3E0D60222EA1AA2006E2053 /* Comparable+Clamp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Comparable+Clamp.swift"; sourceTree = "<group>"; };
@@ -690,12 +696,15 @@
 				EAAFBCEC2302D8C8004F553D /* CompoundMessagePresenterTests.swift */,
 				EAAFBCEA2302BBD3004F553D /* DefaultMessageContentPresenterTests.swift */,
 				EAAFBCF02302DBAF004F553D /* FakeMessageInteractionHandler.swift */,
+				D6E3AEFB25D6E01900819A56 /* FakeMessageModel.swift */,
 				EAAFBCEE2302DB22004F553D /* FakeViewModelBuilder.swift */,
 				EA75254F2302E94B0069D1AF /* MessageModel+Helpers.swift */,
+				D6E3AEF525D6DF6000819A56 /* MessageViewModelTests.swift */,
 				EA7527972302FD790069D1AF /* StubCompoundBubbleViewStyle.swift */,
 				EA7527992302FD980069D1AF /* StubMessageCollectionViewCellStyle.swift */,
 				EA75279B23031FE60069D1AF /* TestableCompoundMessagePresenter.swift */,
 				EA7525512302FB930069D1AF /* TestHelpers.swift */,
+				D6E3AF0025D6E6C500819A56 /* FakeMessageContentFactory.swift */,
 			);
 			path = BaseMessage;
 			sourceTree = "<group>";
@@ -1029,6 +1038,7 @@
 			files = (
 				C3C0CC861BFE49700052747C /* ChatInputItemTests.swift in Sources */,
 				CDC6100B1FD8268200C2588E /* FakePhotosInputDataProvider.swift in Sources */,
+				D6E3AEFC25D6E01900819A56 /* FakeMessageModel.swift in Sources */,
 				EAAFBCEB2302BBD3004F553D /* DefaultMessageContentPresenterTests.swift in Sources */,
 				EAAFBCEF2302DB22004F553D /* FakeViewModelBuilder.swift in Sources */,
 				EA75279A2302FD980069D1AF /* StubMessageCollectionViewCellStyle.swift in Sources */,
@@ -1043,6 +1053,7 @@
 				C35FE3C51C0331CF00D42980 /* TextMessagePresenterTests.swift in Sources */,
 				55ABA5731FC74E0400923302 /* UIEdgeInets+AdditionsTests.swift in Sources */,
 				C3C0CC8A1BFE49700052747C /* PhotosChatInputItemTests.swift in Sources */,
+				D6E3AF0125D6E6C500819A56 /* FakeMessageContentFactory.swift in Sources */,
 				EA7525502302E94B0069D1AF /* MessageModel+Helpers.swift in Sources */,
 				EAAFBCED2302D8C8004F553D /* CompoundMessagePresenterTests.swift in Sources */,
 				55ABA5691FC7498700923302 /* CGRect+AdditionsTests.swift in Sources */,
@@ -1054,6 +1065,7 @@
 				E3E0D60522EA1AEE006E2053 /* Comparable+ClampTests.swift in Sources */,
 				55ABA5591FC73B5600923302 /* CGSize+AdditionsTests.swift in Sources */,
 				C3C0CC871BFE49700052747C /* ChatInputItemViewTests.swift in Sources */,
+				D6E3AEF625D6DF6000819A56 /* MessageViewModelTests.swift in Sources */,
 				CDC6100D1FD8376000C2588E /* PhotosInputCellProviderTests.swift in Sources */,
 				C35FE3C81C033E7800D42980 /* PhotoMessagePresenterTests.swift in Sources */,
 				C3EFA6B01C03607A0063CE22 /* BaseMessagePresenterTests.swift in Sources */,

--- a/ChattoAdditions/Source/Chat Items/BaseMessage/BaseMessageViewModel.swift
+++ b/ChattoAdditions/Source/Chat Items/BaseMessage/BaseMessageViewModel.swift
@@ -51,6 +51,7 @@ public protocol MessageViewModelProtocol: class { // why class? https://gist.git
     var date: String { get }
     var status: MessageViewModelStatus { get }
     var avatarImage: Observable<UIImage?> { get set }
+    var messageContentTransferStatus: TransferStatus? { get set }
     var canReply: Bool { get }
     func willBeShown() // Optional
     func wasHidden() // Optional
@@ -95,6 +96,14 @@ extension DecoratedMessageViewModelProtocol {
         return self.messageViewModel.date
     }
 
+    public var messageContentTransferStatus: TransferStatus? {
+        get {
+            return nil
+        }
+        set {
+        }
+    }
+
     public var status: MessageViewModelStatus {
         return self.messageViewModel.status
     }
@@ -124,8 +133,15 @@ open class MessageViewModel: MessageViewModelProtocol {
     open var decorationAttributes: BaseMessageDecorationAttributes
     open var isUserInteractionEnabled: Bool = true
 
+    public var messageContentTransferStatus: TransferStatus?
+
     open var status: MessageViewModelStatus {
-        return self.messageModel.status.viewModelStatus()
+        let deliveryStatus = self.messageModel.status.viewModelStatus()
+        guard let contentLoadStatus = self.messageContentTransferStatus else { return deliveryStatus }
+        if contentLoadStatus == .failed {
+            return .failed
+        }
+        return deliveryStatus
     }
 
     open lazy var date: String = {

--- a/ChattoAdditions/Source/Chat Items/BaseMessage/Views/BaseMessageCollectionViewCell.swift
+++ b/ChattoAdditions/Source/Chat Items/BaseMessage/Views/BaseMessageCollectionViewCell.swift
@@ -285,6 +285,7 @@ open class BaseMessageCollectionViewCell<BubbleViewType>: UICollectionViewCell, 
             self.failedButton.alpha = 0
         }
         if oldAlpha != self.failedButton.alpha {
+            // to recalculate bubble offsets
             self.setNeedsLayout()
         }
     }

--- a/ChattoAdditions/Source/Chat Items/BaseMessage/Views/BaseMessageCollectionViewCell.swift
+++ b/ChattoAdditions/Source/Chat Items/BaseMessage/Views/BaseMessageCollectionViewCell.swift
@@ -258,13 +258,7 @@ open class BaseMessageCollectionViewCell<BubbleViewType>: UICollectionViewCell, 
         if self.isUpdating { return }
         guard let viewModel = self.messageViewModel, let style = self.baseStyle else { return }
         self.bubbleView.isUserInteractionEnabled = viewModel.isUserInteractionEnabled
-        if self.shouldShowFailedIcon {
-            self.failedButton.setImage(self.baseStyle.failedIcon, for: .normal)
-            self.failedButton.setImage(self.baseStyle.failedIconHighlighted, for: .highlighted)
-            self.failedButton.alpha = 1
-        } else {
-            self.failedButton.alpha = 0
-        }
+        self.updateFailedIconState()
         self.accessoryTimestampView.attributedText = style.attributedStringForDate(viewModel.date)
         self.updateSelectionIndicator(with: style)
 
@@ -279,6 +273,20 @@ open class BaseMessageCollectionViewCell<BubbleViewType>: UICollectionViewCell, 
 
         self.setNeedsLayout()
         self.layoutIfNeeded()
+    }
+
+    public func updateFailedIconState() {
+        let oldAlpha = self.failedButton.alpha
+        if self.shouldShowFailedIcon {
+            self.failedButton.setImage(self.baseStyle.failedIcon, for: .normal)
+            self.failedButton.setImage(self.baseStyle.failedIconHighlighted, for: .highlighted)
+            self.failedButton.alpha = 1
+        } else {
+            self.failedButton.alpha = 0
+        }
+        if oldAlpha != self.failedButton.alpha {
+            self.setNeedsLayout()
+        }
     }
 
     private func observeAvatar() {

--- a/ChattoAdditions/Source/Chat Items/CompoundMessage/CompoundMessagePresenter.swift
+++ b/ChattoAdditions/Source/Chat Items/CompoundMessage/CompoundMessagePresenter.swift
@@ -337,10 +337,7 @@ open class CompoundMessagePresenter<ViewModelBuilderT, InteractionHandlerT>
         let currentContentStatus = self.messageViewModel.messageContentTransferStatus
         guard currentContentStatus != aggregatedContentStatus else { return }
 
-        let shouldUpdateCell = !((currentContentStatus == .failed) && (aggregatedContentStatus == .transfering))
         self.messageViewModel.messageContentTransferStatus = aggregatedContentStatus
-        if shouldUpdateCell {
-            self.cell?.updateFailedIconState()
-        }
+        self.cell?.updateFailedIconState()
     }
 }

--- a/ChattoAdditions/Source/Chat Items/CompoundMessage/Content/DefaultMessageContentPresenter.swift
+++ b/ChattoAdditions/Source/Chat Items/CompoundMessage/Content/DefaultMessageContentPresenter.swift
@@ -73,6 +73,7 @@ public final class DefaultMessageContentPresenter<MessageType, ViewType: UIView>
     public func contentWillBeShown() { self.onContentWillBeShown?(self.message, self.view) }
     public func contentWasHidden() { self.onContentWasHidden?(self.message, self.view) }
     public func contentWasTapped_deprecated() { self.onContentWasTapped_deprecated?(self.message, self.view) }
+    public func handleFailedIconTap() {}
 
     public func bindToView(with viewReference: ViewReference) {
         self.viewReference = viewReference

--- a/ChattoAdditions/Source/Chat Items/CompoundMessage/Content/MessageContentPresenterProtocol.swift
+++ b/ChattoAdditions/Source/Chat Items/CompoundMessage/Content/MessageContentPresenterProtocol.swift
@@ -59,7 +59,7 @@ public protocol MessageContentPresenterProtocol {
     func updateMessage(_ newMessage: Any)
 }
 
-public protocol FailableMessageContentPresenter: MessageContentPresenterProtocol {
+public protocol FailableMessageContentPresenterProtocol: MessageContentPresenterProtocol {
     var contentTransferStatus: Observable<TransferStatus>? { get }
     func handleFailedIconTap()
 }

--- a/ChattoAdditions/Source/Chat Items/CompoundMessage/Content/MessageContentPresenterProtocol.swift
+++ b/ChattoAdditions/Source/Chat Items/CompoundMessage/Content/MessageContentPresenterProtocol.swift
@@ -59,6 +59,12 @@ public protocol MessageContentPresenterProtocol {
     func updateMessage(_ newMessage: Any)
 }
 
+public protocol FailableMessageContentPresenter: MessageContentPresenterProtocol {
+    var contentTransferStatus: Observable<TransferStatus>? { get }
+    func handleFailedIconTap()
+}
+
 public extension MessageContentPresenterProtocol {
     var supportsMessageUpdating: Bool { return false }
+    var contentTransferStatus: TransferStatus? { nil }
 }

--- a/ChattoAdditions/Tests/Chat Items/BaseMessage/CompoundMessagePresenterTests.swift
+++ b/ChattoAdditions/Tests/Chat Items/BaseMessage/CompoundMessagePresenterTests.swift
@@ -67,8 +67,8 @@ final class CompoundMessagePresenterTests: XCTestCase {
         let (presenter, viewModel) = try self.makeRealPresenter(contentTransferStatus: contentTransferStatus)
         contentTransferStatus.value = .failed
         XCTAssertEqual(viewModel.messageContentTransferStatus, .failed)
-        // to get rid of the warning about not used variable
-        XCTAssert(presenter === presenter)
+        // to avoid the warning about not used variable
+        _ = presenter
     }
 
     func test_GivenFailableContentPresenter_WhenItsContentTurnsToFailedToSuccess_ThenViewModelStatusUpdatedToSuccess() throws {
@@ -76,8 +76,8 @@ final class CompoundMessagePresenterTests: XCTestCase {
         let (presenter, viewModel) = try self.makeRealPresenter(contentTransferStatus: contentTransferStatus)
         contentTransferStatus.value = .success
         XCTAssertEqual(viewModel.messageContentTransferStatus, .success)
-        // to get rid of the warning about not used variable
-        XCTAssert(presenter === presenter)
+        // to avoid the warning about not used variable
+        _ = presenter
     }
 
     func test_GivenContentPresenterWithFailedContentAndMessageWithFailedDeliveryStauts_WhenFailIconTapped_ThenInteractionHandlerCalled() throws {

--- a/ChattoAdditions/Tests/Chat Items/BaseMessage/FakeMessageContentFactory.swift
+++ b/ChattoAdditions/Tests/Chat Items/BaseMessage/FakeMessageContentFactory.swift
@@ -1,0 +1,91 @@
+//
+// The MIT License (MIT)
+//
+// Copyright (c) 2015-present Badoo Trading Limited.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+
+import Chatto
+import ChattoAdditions
+import UIKit
+
+final class FakeMessageContentFactory<T: MessageModelProtocol>: MessageContentFactoryProtocol {
+    var fakeContentView: UIView = UIView()
+    var canCreateMessageContentValue = true
+    var fakeContentPresenter = FakeMessageContentPresenter()
+    var fakeLayoutProvider = FakeMessageManualLayoutProvider()
+
+    func canCreateMessageContent(forModel model: T) -> Bool {
+        return self.canCreateMessageContentValue
+    }
+
+    func createContentView() -> UIView {
+        return self.fakeContentView
+    }
+
+    func createContentPresenter(forModel model: T) -> MessageContentPresenterProtocol {
+        return self.fakeContentPresenter
+    }
+
+    func createLayoutProvider(forModel model: T) -> MessageManualLayoutProviderProtocol {
+        return self.fakeLayoutProvider
+    }
+
+    func createMenuPresenter(forModel model: T) -> ChatItemMenuPresenterProtocol? {
+        return nil
+    }
+}
+
+final class FakeMessageContentPresenter: FailableMessageContentPresenterProtocol {
+    var contentTransferStatus: Observable<TransferStatus>?
+    weak var delegate: MessageContentPresenterDelegate?
+    var showBorder: Bool = false
+
+    var wasHandleFailedIconTapCalled = false
+
+    func contentWillBeShown() {
+    }
+
+    func contentWasHidden() {
+    }
+
+    func contentWasTapped_deprecated() {
+    }
+
+    func bindToView(with viewReference: ViewReference) {
+    }
+
+    func unbindFromView() {
+    }
+
+    func updateMessage(_ newMessage: Any) {
+    }
+
+    func handleFailedIconTap() {
+        self.wasHandleFailedIconTapCalled = true
+    }
+}
+
+final class FakeMessageManualLayoutProvider: MessageManualLayoutProviderProtocol {
+    var asHashable: AnyHashable { return "" as AnyHashable }
+    func layoutThatFits(size: CGSize, safeAreaInsets: UIEdgeInsets) -> LayoutInfo {
+        return LayoutInfo(size: .zero, contentInsets: .zero)
+    }
+}

--- a/ChattoAdditions/Tests/Chat Items/BaseMessage/FakeMessageModel.swift
+++ b/ChattoAdditions/Tests/Chat Items/BaseMessage/FakeMessageModel.swift
@@ -1,0 +1,36 @@
+//
+// The MIT License (MIT)
+//
+// Copyright (c) 2015-present Badoo Trading Limited.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import Foundation
+import ChattoAdditions
+import Chatto
+
+final class FakeMessageModel: MessageModelProtocol {
+    var uid: String = UUID().uuidString
+    var type: ChatItemType = "fake"
+    var senderId: String = ""
+    var isIncoming: Bool = false
+    var date: Date = Date(timeIntervalSince1970: 0)
+    var status: MessageStatus = .success
+    var canReply: Bool = false
+}

--- a/ChattoAdditions/Tests/Chat Items/BaseMessage/MessageViewModelTests.swift
+++ b/ChattoAdditions/Tests/Chat Items/BaseMessage/MessageViewModelTests.swift
@@ -1,0 +1,91 @@
+//
+// The MIT License (MIT)
+//
+// Copyright (c) 2015-present Badoo Trading Limited.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import XCTest
+@testable import ChattoAdditions
+
+final class MessageViewModelTests: XCTestCase {
+    private let dateFormatter = DateFormatter()
+    private var messageModel: FakeMessageModel!
+    private var viewModel: MessageViewModel!
+
+    override func setUp() {
+        super.setUp()
+        self.messageModel = FakeMessageModel()
+        self.viewModel = MessageViewModel(dateFormatter: self.dateFormatter,
+                                          messageModel: self.messageModel,
+                                          avatarImage: nil,
+                                          decorationAttributes: BaseMessageDecorationAttributes())
+    }
+
+    // MARK: - Failed Icon
+    func test_GivenModelWithSuccessState_WhenContentTransferStatusSetToFailed_ThenViewModelStatusIsFailed() {
+        self.messageModel.status = .success
+        self.viewModel.messageContentTransferStatus = .failed
+        XCTAssertEqual(viewModel.status, .failed)
+    }
+
+    func test_GivenModelWithFailedState_WhenContentTransferStatusSetToSuccess_ThenViewModelStatusIsFailed() {
+        self.messageModel.status = .failed
+        self.viewModel.messageContentTransferStatus = .success
+        XCTAssertEqual(viewModel.status, .failed)
+    }
+
+    func test_GivenModelWithSuccessState_WhenContentTransferIsNotSet_ThenViewModelStatusIsSuccess() {
+        self.messageModel.status = .success
+        self.viewModel.messageContentTransferStatus = nil
+        XCTAssertEqual(viewModel.status, .success)
+    }
+
+    func test_WhenViewModelStateIsFailed_ThenIsShowingFailedIconIsTrue() {
+        self.forceViewModelState(to: .failed)
+        XCTAssert(self.viewModel.isShowingFailedIcon)
+    }
+
+    func test_WhenViewModelStateIsSuccess_ThenIsShowingFailedIconIsFalse() {
+        self.forceViewModelState(to: .success)
+        XCTAssertFalse(self.viewModel.isShowingFailedIcon)
+    }
+
+    // MARK: - Flags logic
+    func test_WhenViewModelReplyStateIsRequested_ThenTheValueIsTakenFromTheMessageModel() {
+        let flagValues = [true, false]
+        for flag in flagValues {
+            self.messageModel.canReply = flag
+            XCTAssertEqual(self.viewModel.canReply, flag)
+        }
+    }
+
+    func test_WhenViewModelDirecitionIsRequested_ThenTheValueIsTakenFromTheMessageModel() {
+        let flagValues = [true, false]
+        for flag in flagValues {
+            self.messageModel.isIncoming = flag
+            XCTAssertEqual(self.viewModel.isIncoming, flag)
+        }
+    }
+
+    // MARK: - Private helpers
+    private func forceViewModelState(to state: MessageStatus) {
+        self.messageModel.status = state
+    }
+}


### PR DESCRIPTION
Added an ability to show failed icon when content of some message wrapped in a compound message is failed to load.
When it happened and the message itself is delivered, a content presenter itself should handle the tap on the failed button.