### PR TITLE
Added camera type to callback when a photo is taken

### DIFF
--- a/ChattoAdditions/Source/Input/Photos/Camera/DeviceImagePicker.swift
+++ b/ChattoAdditions/Source/Input/Photos/Camera/DeviceImagePicker.swift
@@ -26,11 +26,13 @@ import UIKit
 
 final class DeviceImagePicker: NSObject, ImagePicker, UIImagePickerControllerDelegate, UINavigationControllerDelegate {
     let controller: UIViewController
+    var cameraType: CameraType { CameraType(self.pickerController.cameraDevice) }
+    
     private weak var delegate: ImagePickerDelegate?
+    private let pickerController = UIImagePickerController()
 
     init(_ delegate: ImagePickerDelegate) {
-        let pickerController = UIImagePickerController()
-        self.controller = pickerController
+        self.controller = self.pickerController
         self.delegate = delegate
         super.init()
         pickerController.delegate = self
@@ -54,5 +56,16 @@ final class DeviceImagePickerFactory: ImagePickerFactory {
             return nil
         }
         return DeviceImagePicker(delegate)
+    }
+}
+
+private extension CameraType {
+
+    init(_ device: UIImagePickerController.CameraDevice) {
+        switch device {
+        case .front: self = .front
+        case .rear: self = .rear
+        @unknown default: fatalError("Unable to map unknown device type \(device.rawValue). Do you have a fancy device with a third camera type?!")
+        }
     }
 }

--- a/ChattoAdditions/Source/Input/Photos/Camera/ImagePicker.swift
+++ b/ChattoAdditions/Source/Input/Photos/Camera/ImagePicker.swift
@@ -31,6 +31,7 @@ public protocol ImagePickerDelegate: class {
 
 public protocol ImagePicker: class {
     var controller: UIViewController { get }
+    var cameraType: CameraType { get }
 }
 
 public protocol ImagePickerFactory: class {

--- a/ChattoAdditions/Source/Input/Photos/PhotosInputView.swift
+++ b/ChattoAdditions/Source/Input/Photos/PhotosInputView.swift
@@ -38,8 +38,12 @@ public protocol PhotosInputViewProtocol {
     var presentingController: UIViewController? { get }
 }
 
-public enum PhotosInputViewPhotoSource {
-    case camera
+public enum CameraType {
+    case front, rear
+}
+
+public enum PhotosInputViewPhotoSource: Equatable {
+    case camera(CameraType)
     case gallery
 }
 
@@ -230,11 +234,10 @@ extension PhotosInputView: UICollectionViewDelegateFlowLayout {
                 self.delegate?.inputViewDidRequestCameraPermission(self)
             } else {
                 self.liveCameraPresenter.cameraPickerWillAppear()
-                self.cameraPicker.presentCameraPicker(onImageTaken: { [weak self] (image) in
+                self.cameraPicker.presentCameraPicker(onImageTaken: { [weak self] (result) in
                     guard let sSelf = self else { return }
-
-                    if let image = image {
-                        sSelf.delegate?.inputView(sSelf, didSelectImage: image, source: .camera)
+                    if let result = result {
+                        sSelf.delegate?.inputView(sSelf, didSelectImage: result.image, source: .camera(result.cameraType))
                     }
                 }, onCameraPickerDismissed: { [weak self] in
                     self?.liveCameraPresenter.cameraPickerDidDisappear()

--- a/ChattoAdditions/Tests/Input/PhotosChatInputItemTests.swift
+++ b/ChattoAdditions/Tests/Input/PhotosChatInputItemTests.swift
@@ -49,7 +49,7 @@ class PhotosChatInputItemTests: XCTestCase {
         XCTAssertFalse(handled)
     }
 
-    func testThat_WhenInputViewSelectsImage_ItemPassedImageIntoPhotoHandler() {
+    func testThat_WhenInputViewSelectsImageFromFrontCamera_ItemPassedImageIntoPhotoHandler() {
         var handledImage: UIImage?
         var handledSource: PhotosInputViewPhotoSource?
         self.inputItem.photoInputHandler = { image, source in
@@ -57,7 +57,23 @@ class PhotosChatInputItemTests: XCTestCase {
             handledSource = source
         }
         let image = UIImage()
-        let source = PhotosInputViewPhotoSource.camera
+        let source = PhotosInputViewPhotoSource.camera(.front)
+        let inputView = MockPhotosInputView()
+        self.inputItem.inputView(inputView, didSelectImage: image, source: source)
+
+        XCTAssertEqual(handledImage!, image)
+        XCTAssertEqual(handledSource!, source)
+    }
+
+    func testThat_WhenInputViewSelectsImageFromRearCamera_ItemPassedImageIntoPhotoHandler() {
+        var handledImage: UIImage?
+        var handledSource: PhotosInputViewPhotoSource?
+        self.inputItem.photoInputHandler = { image, source in
+            handledImage = image
+            handledSource = source
+        }
+        let image = UIImage()
+        let source = PhotosInputViewPhotoSource.camera(.rear)
         let inputView = MockPhotosInputView()
         self.inputItem.inputView(inputView, didSelectImage: image, source: source)
 

--- a/ChattoAdditions/Tests/Input/PhotosInputCameraPickerTests.swift
+++ b/ChattoAdditions/Tests/Input/PhotosInputCameraPickerTests.swift
@@ -70,12 +70,28 @@ class PhotosInputCameraPickerTests: XCTestCase {
         XCTAssertTrue(onCameraPickerDismissedCalled)
     }
 
-    func testThat_GivenPresentedPicker_WhenPickerFinishedWithImage_ThenOnImageTakenCallbackReceivedImage() {
+    func testThat_GivenPresentedPicker_WhenPickerFinishedWithImageFromFrontCamera_ThenOnImageTakenCallbackReceivedImage() {
         // Given
         var onImageTakenCalled = false
         self.sut.presentCameraPicker(onImageTaken: { (image) in
             onImageTakenCalled = true
             XCTAssertNotNil(image)
+            XCTAssertEqual(image?.cameraType, .front)
+        }, onCameraPickerDismissed: {})
+        // When
+        self.fakeImagePicker.finish(with: [UIImagePickerController.InfoKey.originalImage: UIImage()])
+        // Then
+        XCTAssertTrue(onImageTakenCalled)
+    }
+
+    func testThat_GivenPresentedPicker_WhenPickerFinishedWithImageFromRearCamera_ThenOnImageTakenCallbackReceivedImage() {
+        // Given
+        var onImageTakenCalled = false
+        self.fakeImagePicker.cameraType = .rear
+        self.sut.presentCameraPicker(onImageTaken: { (image) in
+            onImageTakenCalled = true
+            XCTAssertNotNil(image)
+            XCTAssertEqual(image?.cameraType, .rear)
         }, onCameraPickerDismissed: {})
         // When
         self.fakeImagePicker.finish(with: [UIImagePickerController.InfoKey.originalImage: UIImage()])
@@ -111,6 +127,8 @@ class PhotosInputCameraPickerTests: XCTestCase {
 }
 
 private class FakeImagePicker: ImagePicker {
+    var cameraType: CameraType = .front
+
     let controller: UIViewController = DummyViewController()
     weak var delegate: ImagePickerDelegate?
 


### PR DESCRIPTION
This PR adds support for providing the camera device / type of camera that took a photo (i.e either front or rear facing camera).

An associated value is added to the `PhotosInputViewPhotoSource.camera` case, with a value of a newly added `CameraType` enum type (eitherr `front` or `rear`.

This shouldn't be a breaking change for consumers of the API because you can still do:

```swift
switch source {
case .gallery: break
case .camera: break
}
```

But now you can also do:

```swift
switch source {
case .gallery: break
case let .camera(cameraType): break
}
```