### PR TITLE
Make presenter public to fire send

### DIFF
--- a/ChattoAdditions/Source/Input/ChatInputBar.swift
+++ b/ChattoAdditions/Source/Input/ChatInputBar.swift
@@ -46,7 +46,7 @@ open class ChatInputBar: ReusableXibView {
     }
 
     public weak var delegate: ChatInputBarDelegate?
-    weak var presenter: ChatInputBarPresenter?
+    public weak var presenter: ChatInputBarPresenter?
 
     public var shouldEnableSendButton = { (inputBar: ChatInputBar) -> Bool in
         return !inputBar.textView.text.isEmpty
@@ -289,7 +289,7 @@ extension ChatInputBar: UITextViewDelegate {
         self.delegate?.inputBarDidChangeText(self)
     }
 
-    public func textView(_ textView: UITextView, shouldChangeTextIn nsRange: NSRange, replacementText text: String) -> Bool {
+    open func textView(_ textView: UITextView, shouldChangeTextIn nsRange: NSRange, replacementText text: String) -> Bool {
         guard let maxCharactersCount = self.maxCharactersCount else { return true }
         let currentText: NSString = textView.text as NSString
         let currentCount = currentText.length

--- a/ChattoAdditions/Source/Input/ChatInputBarPresenter.swift
+++ b/ChattoAdditions/Source/Input/ChatInputBarPresenter.swift
@@ -24,7 +24,7 @@
 
 import UIKit
 
-protocol ChatInputBarPresenter: class {
+public protocol ChatInputBarPresenter: class {
     var focusedItem: ChatInputItemProtocol? { get }
     var chatInputBar: ChatInputBar { get }
     func onDidBeginEditing()
@@ -61,7 +61,7 @@ public class BasicChatInputBarPresenter: NSObject, ChatInputBarPresenter {
         self.notificationCenter.removeObserver(self)
     }
 
-    fileprivate(set) var focusedItem: ChatInputItemProtocol? {
+    fileprivate(set) public var focusedItem: ChatInputItemProtocol? {
         willSet {
             self.focusedItem?.selected = false
         }
@@ -172,7 +172,7 @@ extension BasicChatInputBarPresenter {
         }
     }
 
-    func onSendButtonPressed() {
+    public func onSendButtonPressed() {
         if let focusedItem = self.focusedItem {
             focusedItem.handleInput(self.chatInputBar.inputText as AnyObject)
         } else if let keyboardItem = self.firstKeyboardInputItem() {
@@ -181,7 +181,7 @@ extension BasicChatInputBarPresenter {
         self.chatInputBar.inputText = ""
     }
 
-    func onDidReceiveFocusOnItem(_ item: ChatInputItemProtocol) {
+    public func onDidReceiveFocusOnItem(_ item: ChatInputItemProtocol) {
         guard item.presentationMode != .none else { return }
         guard item !== self.focusedItem else { return }
 

--- a/ChattoAdditions/Source/Input/ExpandableChatInputBarPresenter.swift
+++ b/ChattoAdditions/Source/Input/ExpandableChatInputBarPresenter.swift
@@ -59,7 +59,7 @@ public class ExpandableChatInputBarPresenter: NSObject, ChatInputBarPresenter {
         self.notificationCenter.removeObserver(self)
     }
 
-    fileprivate(set) var focusedItem: ChatInputItemProtocol? {
+    fileprivate(set) public var focusedItem: ChatInputItemProtocol? {
         willSet {
             self.focusedItem?.selected = false
         }
@@ -267,7 +267,7 @@ extension ExpandableChatInputBarPresenter {
         }
     }
 
-    func onSendButtonPressed() {
+    public func onSendButtonPressed() {
         if let focusedItem = self.focusedItem {
             focusedItem.handleInput(self.chatInputBar.inputText as AnyObject)
         } else if let keyboardItem = self.firstKeyboardInputItem() {
@@ -276,7 +276,7 @@ extension ExpandableChatInputBarPresenter {
         self.chatInputBar.inputText = ""
     }
 
-    func onDidReceiveFocusOnItem(_ item: ChatInputItemProtocol) {
+    public func onDidReceiveFocusOnItem(_ item: ChatInputItemProtocol) {
         guard item.presentationMode != .none else { return }
         guard item !== self.focusedItem else { return }
 


### PR DESCRIPTION
Some properties were missing a `public` accessor level like the rest.

Additionally it changes the `public` level to `open` for `func textView(_ textView: UITextView, shouldChangeTextIn nsRange: NSRange, replacementText text: String)` as this method is commonly used to overwrite the `UITextView` behavior of accepting/modifying text input.