### PR TITLE
Adding allow timestamp revealing boolean

### DIFF
--- a/Chatto/Source/ChatController/Collaborators/CellPanGestureHandler.swift
+++ b/Chatto/Source/ChatController/Collaborators/CellPanGestureHandler.swift
@@ -50,6 +50,7 @@ public struct CellPanGestureHandlerConfig {
     public let accessoryViewTranslationMultiplier: CGFloat
     public let replyIndicatorTranslationMultiplier: CGFloat
     public var allowReplyRevealing: Bool = false
+    public var allowTimestampRevealing: Bool = true
 
     public static func defaultConfig() -> CellPanGestureHandlerConfig {
         .init(
@@ -105,6 +106,7 @@ final class CellPanGestureHandler: NSObject, UIGestureRecognizerDelegate {
         case .changed:
             let translation = panRecognizer.translation(in: self.collectionView)
             if translation.x < 0 {
+                guard self.config.allowTimestampRevealing else { return }
                 self.revealAccessoryView(atOffset: self.config.transformAccessoryViewTranslation(-translation.x))
             } else {
                 guard let indexPath = self.collectionView.indexPathForItem(at: panRecognizer.location(in: self.collectionView)),


### PR DESCRIPTION
This change is required in order to allow a different timestamp revealing behaviour (managed by the CellPanGestureHandler) of the apps that share the same implementation of this framework. This PR simply adds a new boolean called allowTimestampRevealing (defaulted to true in order to ensure backward compatibility) which the CellPanGestureHandler guards against when a right to left pan is detected (translation.x < 0).