### PR TITLE
Fix bottomConstraint calculation bug when rendering custom keyboards (such as Microsoft Swiftkey) for the first time

### DIFF
--- a/Chatto/Source/ChatController/Collaborators/KeyboardTracker.swift
+++ b/Chatto/Source/ChatController/Collaborators/KeyboardTracker.swift
@@ -53,6 +53,7 @@ class KeyboardTracker {
     var isTracking = false
     var inputBarContainer: UIView
     private var notificationCenter: NotificationCenter
+    private var bottomConstraintSizeAtKeyboardShow: CGFloat?
 
     private var heightBlock: KeyboardHeightBlock
 
@@ -121,19 +122,30 @@ class KeyboardTracker {
         guard !self.isPerformingForcedLayout else { return }
 
         let bottomConstraint = self.bottomConstraintFromNotification(notification)
+
         guard bottomConstraint > 0 else { return } // Some keyboards may report initial willShow/DidShow notifications with invalid positions
-        self.keyboardStatus = .shown
-        self.layoutInputContainer(withBottomConstraint: bottomConstraint)
-        self.adjustTrackingViewSizeIfNeeded()
+
+        // Some keyboards report sizes during keyboardDidShow that change
+        // only after they have fully rendered, such as Microsoft Swiftkey
+        self.bottomConstraintSizeAtKeyboardShow = bottomConstraint
+
+        self.showKeyboard(withBottomConstraint: bottomConstraint)
     }
 
     @objc
     private func keyboardWillChangeFrame(_ notification: Notification) {
         guard self.isTracking else { return }
         let bottomConstraint = self.bottomConstraintFromNotification(notification)
+
+        // In the event that our keyboard has changed its frame from the first
+        // time it was displayed, we will want to trigger another layout
+        let didBottomConstraintChange = self.bottomConstraintSizeAtKeyboardShow != nil && self.bottomConstraintSizeAtKeyboardShow != bottomConstraint
+
         if bottomConstraint == 0 {
             self.keyboardStatus = .hiding
             self.layoutInputAtBottom()
+        } else if didBottomConstraintChange {
+            self.showKeyboard(withBottomConstraint: bottomConstraint)
         }
     }
 
@@ -202,6 +214,12 @@ class KeyboardTracker {
         self.isPerformingForcedLayout = true
         self.heightBlock(constraint, self.keyboardStatus)
         self.isPerformingForcedLayout = false
+    }
+
+    private func showKeyboard(withBottomConstraint bottomConstraint: CGFloat) {
+        self.keyboardStatus = .shown
+        self.layoutInputContainer(withBottomConstraint: bottomConstraint)
+        self.adjustTrackingViewSizeIfNeeded()
     }
 }
 


### PR DESCRIPTION
This PR addresses issue: https://github.com/badoo/Chatto/issues/708

I did my best to limit the scope of this change and fit things into the patterns established in `KeyboardTracker.swift`

If you all have feedback or preferences for how to do this differently I am happy to oblige. This bug is a 100% repro (see video in the associated bug report) so should be easy to repro on your end if you want to go a different direction.