### PR TITLE
Invalidate layout when view is transitioning sizes

### DIFF
--- a/Chatto/Source/ChatController/BaseChatViewController.swift
+++ b/Chatto/Source/ChatController/BaseChatViewController.swift
@@ -588,6 +588,7 @@ extension BaseChatViewController { // Rotation
         let shouldScrollToBottom = self.isScrolledAtBottom()
         let referenceIndexPath = collectionView.indexPathsForVisibleItems.first
         let oldRect = self.rectAtIndexPath(referenceIndexPath)
+        collectionView.collectionViewLayout.invalidateLayout()
         coordinator.animate(alongsideTransition: { (_) -> Void in
             if shouldScrollToBottom {
                 self.scrollToBottom(animated: false)


### PR DESCRIPTION
Fix issue where cells are not drawn properly when rotating from portrait to landscape

This addresses issue https://github.com/badoo/Chatto/issues/712