### PR TITLE
Improve scroll to bottom logic after update

### DIFF
--- a/Chatto/sources/ChatController/ChatMessages/ChatMessageCollectionAdapter.swift
+++ b/Chatto/sources/ChatController/ChatMessages/ChatMessageCollectionAdapter.swift
@@ -418,15 +418,17 @@ extension ChatMessageCollectionAdapter: ChatDataSourceDelegateProtocol {
             }
         }
 
-        let adjustScrollViewToBottom = {
+        let adjustScrollViewToBottom = { [weak self, weak collectionView] in
+            guard let sSelf = self, let collectionView = collectionView else { return }
+
             switch scrollAction {
             case .scrollToBottom:
                 collectionView.scrollToBottom(
                     animated: updateType == .normal,
-                    animationDuration: self.configuration.updatesAnimationDuration
+                    animationDuration: sSelf.configuration.updatesAnimationDuration
                 )
-            case .preservePosition(rectForReferenceIndexPathBeforeUpdate: let oldRect, referenceIndexPathAfterUpdate: let indexPath):
-                let newRect = self.rectAtIndexPath(indexPath)
+            case .preservePosition(let oldRect, let indexPath):
+                let newRect = sSelf.rectAtIndexPath(indexPath)
                 collectionView.scrollToPreservePosition(oldRefRect: oldRect, newRefRect: newRect)
             }
         }


### PR DESCRIPTION
Sometimes, after performing a batch update in the messages collection view, the messages collection view does not scroll to the bottom