### PR TITLE
Remove view model observations

### DIFF
--- a/Chatto/Tests/ChatController/BaseChatViewControllerTestHelpers.swift
+++ b/Chatto/Tests/ChatController/BaseChatViewControllerTestHelpers.swift
@@ -237,7 +237,3 @@ final class FakePresenter: ChatItemPresenterProtocol {
         fakeCell.backgroundColor = UIColor.red
     }
 }
-
-private final class FakeChatViewControllerViewModel: BaseChatViewControllerViewModelProtocol {
-    var onDidUpdate: (() -> Void)?
-}

--- a/Chatto/sources/ChatController/BaseChatViewController.swift
+++ b/Chatto/sources/ChatController/BaseChatViewController.swift
@@ -28,10 +28,6 @@ public protocol ReplyActionHandler: AnyObject {
     func handleReply(for: ChatItemProtocol)
 }
 
-public protocol BaseChatViewControllerViewModelProtocol: AnyObject {
-    var onDidUpdate: (() -> Void)? { get set }
-}
-
 public protocol ItemPositionScrollable: AnyObject {
     func scrollToItem(withId: String,
                       position: UICollectionView.ScrollPosition,

--- a/Chatto/sources/ChatController/Collaborators/ChatDataSourceProtocol.swift
+++ b/Chatto/sources/ChatController/Collaborators/ChatDataSourceProtocol.swift
@@ -38,7 +38,7 @@ public protocol ChatDataSourceDelegateProtocol: AnyObject {
     func chatDataSourceDidUpdate(_ chatDataSource: ChatDataSourceProtocol, updateType: UpdateType)
 }
 
-public protocol ChatDataSourceProtocol: ChatMessagesViewModelProtocol, BaseChatViewControllerViewModelProtocol {
+public protocol ChatDataSourceProtocol: ChatMessagesViewModelProtocol {
     var hasMoreNext: Bool { get }
     var hasMorePrevious: Bool { get }
     var chatItems: [ChatItemProtocol] { get }


### PR DESCRIPTION
View Model is not being observed inside Chatto's View Controllers.
Therefore it makes sense to remove BaseChatViewControllerViewModelProtocol