### PR TITLE
Add iPhone 12 Pro support + use default portrait mode when UIDeviceOrientation is unknown

### DIFF
--- a/ChattoAdditions/sources/Common/ScreenMetric.swift
+++ b/ChattoAdditions/sources/Common/ScreenMetric.swift
@@ -78,10 +78,10 @@ private extension ScreenMetrics {
             return 736
         case .inch5_8:
             return 812
-        case .inch6_1, .inch6_5:
-            return 896
         case .inch6_0_6:
             return 844
+        case .inch6_1, .inch6_5:
+            return 896
         case .inch6_7:
             return 926
         case .iPad:
@@ -114,12 +114,12 @@ extension UIScreen {
             return .inch5_5
         case ScreenMetrics.inch5_8.heightInPoints:
             return .inch5_8
+        case ScreenMetrics.inch6_0_6.heightInPoints:
+            return .inch6_0_6
         case ScreenMetrics.inch6_1.heightInPoints:
             return .inch6_1
         case ScreenMetrics.inch6_5.heightInPoints:
             return .inch6_5
-        case ScreenMetrics.inch6_0_6.heightInPoints:
-            return .inch6_0_6
         case ScreenMetrics.inch6_7.heightInPoints:
             return .inch6_7
         case ScreenMetrics.iPad.heightInPoints:

--- a/ChattoAdditions/sources/Common/ScreenMetric.swift
+++ b/ChattoAdditions/sources/Common/ScreenMetric.swift
@@ -171,12 +171,22 @@ extension UIScreen {
     }
 
     public var defaultKeyboardHeightForCurrentOrientation: CGFloat {
+        return self.defaultKeyboardHeight(isPortrait: UIDevice.current.orientation.isPortrait)
+    }
+
+    public func defaultKeyboardHeightForCurrentOrientation(
+        defaultOrientationAsPortrait: Bool = true
+    ) -> CGFloat {
         let isPortrait = {
             switch UIDevice.current.orientation {
-            case .portrait, .portraitUpsideDown, .unknown:
+            case .portrait, .portraitUpsideDown:
                 return true
-            default:
+            case .unknown, .faceUp, .faceDown:
+                return defaultOrientationAsPortrait
+            case .landscapeLeft, .landscapeRight:
                 return false
+            @unknown default:
+                return defaultOrientationAsPortrait
             }
         }()
 

--- a/ChattoAdditions/sources/Common/ScreenMetric.swift
+++ b/ChattoAdditions/sources/Common/ScreenMetric.swift
@@ -46,8 +46,14 @@ enum ScreenMetrics {
     /// iPhone XR
     case inch6_1
 
+    /// iPhone 12 Pro (6.1 on spec)
+    case inch6_0_6
+
     /// iPhone XMax
     case inch6_5
+
+    /// iPhone 12 Pro MAX
+    case inch6_7
 
     /// iPad, iPad Air, iPad Pro 9.7, iPad Pro 10.5
     case iPad
@@ -73,6 +79,10 @@ private extension ScreenMetrics {
             return 812
         case .inch6_1, .inch6_5:
             return 896
+        case .inch6_0_6:
+            return 844
+        case .inch6_7:
+            return 926
         case .iPad:
             return 1024
         case .iPad_12_9:
@@ -107,6 +117,10 @@ extension UIScreen {
             return .inch6_1
         case ScreenMetrics.inch6_5.heightInPoints:
             return .inch6_5
+        case ScreenMetrics.inch6_0_6.heightInPoints:
+            return .inch6_0_6
+        case ScreenMetrics.inch6_7.heightInPoints:
+            return .inch6_7
         case ScreenMetrics.iPad.heightInPoints:
             return .iPad
         case ScreenMetrics.iPad_12_9.heightInPoints:
@@ -124,16 +138,16 @@ extension UIScreen {
             return 260
         case .inch5_5:
             return 271
-        case .inch5_8:
-            return 335
-        case .inch6_1, .inch6_5:
+        case .inch5_8, .inch6_0_6:
+            return 336
+        case .inch6_1, .inch6_5, .inch6_7:
             return 346
         case .iPad:
             return 313
         case .iPad_12_9:
             return 378
         case .undefined:
-            return 335 // iPhoneX
+            return 336 // iPhoneX
         }
     }
 
@@ -149,13 +163,24 @@ extension UIScreen {
             return 398
         case .iPad_12_9:
             return 471
+        case .inch6_0_6, .inch6_7:
+            return 219
         case .undefined:
             return 209 // iPhone X
         }
     }
 
     public var defaultKeyboardHeightForCurrentOrientation: CGFloat {
-        return self.defaultKeyboardHeight(isPortrait: UIDevice.current.orientation.isPortrait)
+        let isPortrait = {
+            switch UIDevice.current.orientation {
+            case .portrait, .portraitUpsideDown, .unknown:
+                return true
+            default:
+                return false
+            }
+        }()
+
+        return self.defaultKeyboardHeight(isPortrait: isPortrait)
     }
 
     public func defaultKeyboardHeight(isPortrait: Bool) -> CGFloat {

--- a/ChattoAdditions/sources/Common/ScreenMetric.swift
+++ b/ChattoAdditions/sources/Common/ScreenMetric.swift
@@ -62,6 +62,7 @@ enum ScreenMetrics {
     case iPad_12_9
 }
 
+// Keyboard heights can be checked on: https://federicabenacquista.medium.com/list-of-the-official-ios-keyboards-heights-and-how-to-calculate-them-c2b844ef54b9
 private extension ScreenMetrics {
     var heightInPoints: CGFloat {
         switch self {
@@ -175,18 +176,18 @@ extension UIScreen {
     }
 
     public func defaultKeyboardHeightForCurrentOrientation(
-        defaultOrientationAsPortrait: Bool = true
+        fallbackUnknownOrientationAsPortrait: Bool = true
     ) -> CGFloat {
         let isPortrait = {
             switch UIDevice.current.orientation {
             case .portrait, .portraitUpsideDown:
                 return true
             case .unknown, .faceUp, .faceDown:
-                return defaultOrientationAsPortrait
+                return fallbackUnknownOrientationAsPortrait
             case .landscapeLeft, .landscapeRight:
                 return false
             @unknown default:
-                return defaultOrientationAsPortrait
+                return fallbackUnknownOrientationAsPortrait
             }
         }()
 

--- a/ChattoApp/ChattoApp/Source/Chat View Controllers/DemoChatViewController.swift
+++ b/ChattoApp/ChattoApp/Source/Chat View Controllers/DemoChatViewController.swift
@@ -174,7 +174,12 @@ class DemoChatViewController: UIViewController {
             )
             let keyboardHandler = DefaultKeyboardHandler(presenter: presenter)
 
-            return (presenter, keyboardHandler, nil, nil)
+            return ChatInputContainer(
+                presenter: presenter,
+                keyboardHandlerDelegate: keyboardHandler,
+                collectionHandler: nil,
+                viewPresentationHandler: nil
+            )
         }
 
         let presenter = ExpandableChatInputBarPresenter(
@@ -183,7 +188,12 @@ class DemoChatViewController: UIViewController {
                 chatInputBarAppearance: appearance
             )
 
-        return (presenter, presenter, presenter, nil)
+        return ChatInputContainer(
+            presenter: presenter,
+            keyboardHandlerDelegate: presenter,
+            collectionHandler: presenter,
+            viewPresentationHandler: nil
+        )
     }
 
     private static func createChatInputItems(dataSource: DemoChatDataSource,
@@ -490,12 +500,12 @@ private protocol PresenterChatInputItemProtocol: AnyObject {
 
 extension PhotosChatInputItem: PresenterChatInputItemProtocol {}
 
-typealias ChatInputContainer = (
-    presenter: BaseChatInputBarPresenterProtocol,
-    keyboardHandlerDelegate: KeyboardUpdatesHandlerDelegate,
-    collectionHandler: CollectionViewEventsHandling?,
-    viewPresentationHandler: ViewPresentationEventsHandling?
-)
+struct ChatInputContainer {
+    let presenter: BaseChatInputBarPresenterProtocol
+    let keyboardHandlerDelegate: KeyboardUpdatesHandlerDelegate
+    let collectionHandler: CollectionViewEventsHandling?
+    let viewPresentationHandler: ViewPresentationEventsHandling?
+}
 
 private final class DefaultKeyboardHandler: KeyboardUpdatesHandlerDelegate {
 


### PR DESCRIPTION
This PR adds support for iPhone 12 (+) to the `ScreenMetric` and use the `Portrait` mode for when the `UIDeviceOrientation` is unknown which would return the wrong keyboard height in most of the cases.