### PR TITLE
Wrong text calculation on AttributedString

### DIFF
--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -23,5 +23,5 @@ xcodebuild clean build test \
     -workspace $WORKSPACE \
     -scheme $SCHEME \
     -sdk iphonesimulator \
-    -destination 'platform=iOS Simulator,name=iPhone 11' \
+    -destination 'platform=iOS Simulator,name=iPhone 15' \
     -configuration Debug | xcpretty


### PR DESCRIPTION
Add option to pass original NSAttributedString instead of creating an internal one for text calculation