### PR TITLE
Remove extra space between scope and accessor

### DIFF
--- a/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+++ b/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/ChattoAdditions/sources/Chat Items/BaseMessage/Views/BaseMessageCollectionViewCell.swift
+++ b/ChattoAdditions/sources/Chat Items/BaseMessage/Views/BaseMessageCollectionViewCell.swift
@@ -179,7 +179,7 @@ open class BaseMessageCollectionViewCell<BubbleViewType>: UICollectionViewCell, 
         return doubleTapGestureRecognizer
     }()
 
-    public private (set) lazy var longPressGestureRecognizer: UILongPressGestureRecognizer = {
+    public private(set) lazy var longPressGestureRecognizer: UILongPressGestureRecognizer = {
         let longpressGestureRecognizer = UILongPressGestureRecognizer(target: self, action: #selector(BaseMessageCollectionViewCell.bubbleLongPressed(_:)))
         longpressGestureRecognizer.cancelsTouchesInView = true
         longpressGestureRecognizer.delegate = self
@@ -547,12 +547,12 @@ open class BaseMessageCollectionViewCell<BubbleViewType>: UICollectionViewCell, 
 }
 
 private struct Layout {
-    private (set) var size = CGSize.zero
-    private (set) var failedButtonFrame = CGRect.zero
-    private (set) var bubbleViewFrame = CGRect.zero
-    private (set) var avatarViewFrame = CGRect.zero
-    private (set) var selectionIndicatorFrame = CGRect.zero
-    private (set) var preferredMaxWidthForBubble: CGFloat = 0
+    private(set) var size = CGSize.zero
+    private(set) var failedButtonFrame = CGRect.zero
+    private(set) var bubbleViewFrame = CGRect.zero
+    private(set) var avatarViewFrame = CGRect.zero
+    private(set) var selectionIndicatorFrame = CGRect.zero
+    private(set) var preferredMaxWidthForBubble: CGFloat = 0
 
     mutating func calculateLayout(parameters: LayoutParameters) {
         let containerWidth = parameters.containerWidth

--- a/ChattoAdditions/sources/Input/Photos/Camera/LiveCameraCaptureSession.swift
+++ b/ChattoAdditions/sources/Input/Photos/Camera/LiveCameraCaptureSession.swift
@@ -81,7 +81,7 @@ class LiveCameraCaptureSession: LiveCameraCaptureSessionProtocol {
         self.queue.addOperation(operation)
     }
 
-    private (set) var captureLayer: AVCaptureVideoPreviewLayer?
+    private(set) var captureLayer: AVCaptureVideoPreviewLayer?
 
     private lazy var queue: OperationQueue = {
         let queue = OperationQueue()


### PR DESCRIPTION
This PR introduces the following changes:
* Remove extra spaces between scope and accessor. This generates warnings in Xcode 16.4